### PR TITLE
anyAlly targeting and fixing null non-inheritence

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -1256,7 +1256,7 @@ function buildTeambuilderTables() {
 			if (!ModConfig[modConfigId].customTiers) ModConfig[modConfigId].customTiers = [];
 			if (!ModConfig[modConfigId].customDoublesTiers) ModConfig[modConfigId].customDoublesTiers = [];
 			for (const speciesid in modData.FormatsData) {
-				if (modData.FormatsData[speciesid] === undefined && debug) {
+				if (!modData.FormatsData[speciesid] && debug) {
 					console.log('Warning: ' + speciesid + ' does not have tiering data in ' + modConfigId);
 					continue;
 				}

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -583,7 +583,7 @@
 					var tooltipArgs = 'activepokemon|1|' + i;
 
 					var disabled = false;
-					if (moveTarget === 'adjacentAlly' || moveTarget === 'adjacentAllyOrSelf') {
+					if (moveTarget === 'adjacentAlly' || moveTarget === 'adjacentAllyOrSelf' || moveTarget === 'anyAlly') {
 						disabled = true;
 					} else if (moveTarget === 'normal' || moveTarget === 'adjacentFoe') {
 						if (Math.abs(farSlot - i) > 1) disabled = true;
@@ -607,7 +607,7 @@
 					} else if (moveTarget === 'normal' || moveTarget === 'adjacentAlly' || moveTarget === 'adjacentAllyOrSelf') {
 						if (Math.abs(activePos - i) > 1) disabled = true;
 					}
-					if (moveTarget !== 'adjacentAllyOrSelf' && activePos == i) disabled = true;
+					if (moveTarget !== 'adjacentAllyOrSelf' && moveTarget !== 'anyAlly' && activePos == i) disabled = true;
 
 					if (disabled) {
 						targetMenus[1] += '<button disabled="disabled" style="visibility:hidden"></button> ';
@@ -1214,7 +1214,7 @@
 				var isTerastal = !!(this.$('input[name=terastallize]')[0] || '').checked;
 
 				var target = e.getAttribute('data-target');
-				var choosableTargets = {normal: 1, any: 1, adjacentAlly: 1, adjacentAllyOrSelf: 1, adjacentFoe: 1};
+				var choosableTargets = {normal: 1, any: 1, adjacentAlly: 1, adjacentAllyOrSelf: 1, anyAlly: 1, adjacentFoe: 1};
 
 				this.choice.choices.push('move ' + pos + (isMega ? ' mega' : '') + (isZMove ? ' zmove' : '') + (isUltraBurst ? ' ultra' : '') + (isDynamax ? ' dynamax' : '') + (isTerastal ? ' terastallize' : ''));
 				if (nearActive.length > 1 && target in choosableTargets) {

--- a/src/battle-choices.ts
+++ b/src/battle-choices.ts
@@ -183,7 +183,7 @@ class BattleChoiceBuilder {
 		}
 		if (choice.choiceType === 'move') {
 			if (!choice.targetLoc && this.requestLength() > 1) {
-				const choosableTargets = ['normal', 'any', 'adjacentAlly', 'adjacentAllyOrSelf', 'adjacentFoe'];
+				const choosableTargets = ['normal', 'any', 'adjacentAlly', 'adjacentAllyOrSelf', 'anyAlly', 'adjacentFoe'];
 				if (choosableTargets.includes(this.getChosenMove(choice, this.index()).target)) {
 					this.current.move = choice.move;
 					this.current.mega = choice.mega;

--- a/src/battle-dex-data.ts
+++ b/src/battle-dex-data.ts
@@ -1137,7 +1137,7 @@ interface MoveFlags {
 	wind?: 1 | 0;
 }
 
-type MoveTarget = 'normal' | 'any' | 'adjacentAlly' | 'adjacentFoe' | 'adjacentAllyOrSelf' | // single-target
+type MoveTarget = 'normal' | 'any' | 'adjacentAlly' | 'adjacentFoe' | 'adjacentAllyOrSelf' | 'anyAlly' | // single-target
 	'self' | 'randomNormal' | // single-target, automatic
 	'allAdjacent' | 'allAdjacentFoes' | // spread
 	'allySide' | 'foeSide' | 'all'; // side and field

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1484,7 +1484,7 @@ export class Battle {
 
 				if (
 					!target && this.gameType === 'singles' &&
-					!['self', 'allies', 'allySide', 'adjacentAlly', 'adjacentAllyOrSelf', 'allyTeam'].includes(moveTarget)
+					!['self', 'allies', 'allySide', 'adjacentAlly', 'adjacentAllyOrSelf', 'anyAlly', 'allyTeam'].includes(moveTarget)
 				) {
 					// Hardcode for moves without a target in singles
 					foeTargets.push(pokemon.side.foe.active[0]);


### PR DESCRIPTION
-Adds functionality for moves to target the user or any ally, not just adjacent ones, with 'anyAlly'.
-Fixes a crash when using 'null' to stop inheritence of formats-data due to the debug "has no formats-data" statement added for mods

This pull request should be accepted at the same time as the one I made for the server.