### PR TITLE
New client features and fixes

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -33,6 +33,7 @@ for (const modid in Dex.dexes) {
 		if ((/gen\d/.test(modid) && modid.length === 4) || modid === 'base') continue;
 		let teambuilderConfig = Dex.dexes[modid].data.Scripts.teambuilderConfig;
 		teambuilderConfig = teambuilderConfig ? teambuilderConfig : {};
+		if(teambuilderConfig.moveIsNotUseless) teambuilderConfig.moveIsNotUseless = JSON.stringify(teambuilderConfig.moveIsNotUseless.toString());
 		ModConfig[modid] = ModConfig[modid] ? ModConfig[modid] : {};
 		ModConfig[modid] = Object.assign(ModConfig[modid], teambuilderConfig);
 	} catch(err) {
@@ -687,8 +688,6 @@ function buildTeambuilderTables() {
 		const specificItems = [['header', "Pok&eacute;mon-specific items"]];
 		const poorItems = [['header', "Usually useless items"]];
 		const badItems = [['header', "Useless items"]];
-		const unreleasedItems = [];
-		if (genNum === 6) unreleasedItems.push(['header', "Unreleased"]);
 		for (const id of itemList) {
 			const item = Dex.mod(gen).items.get(id);
 			if (item.gen > genNum) {
@@ -706,190 +705,31 @@ function buildTeambuilderTables() {
 				const banlist = Dex.formats.getRuleTable(Dex.formats.get(gen + 'metronomebattle'));
 				if (banlist.isBanned('item:' + item.id)) continue;
 			}
-			switch (id) {
-			case 'leftovers':
-			case 'lifeorb':
-			case 'choiceband':
-			case 'choicescarf':
-			case 'choicespecs':
-			case 'eviolite':
-			case 'assaultvest':
-			case 'focussash':
-			case 'powerherb':
-			case 'rockyhelmet':
-			case 'heavydutyboots':
-			case 'expertbelt':
-			case 'salacberry':
+			if(item.itemUser || item.megaStone || id === 'boosterenergy'){
+				specificItems.push(id);
+				continue;
+			}
+			if(item.isPokeball || item.name.startsWith("TR")){
+				badItems.push(id);
+				continue;
+			}
+			switch (item.rating) {
+			case 3:
 				greatItems.push(id);
 				break;
-			case 'mentalherb':
-				if (genNum > 4) greatItems.push(id);
-				else poorItems.push(id);
-				break;
-			case 'lumberry':
-				if (genNum === 2 || genNum > 6) goodItems.push(id);
-				else greatItems.push(id);
-				break;
-			case 'sitrusberry':
-				if (genNum > 6) goodItems.push(id);
-				else if (genNum > 3 && genNum < 7) greatItems.push(id);
-				else poorItems.push(id);
-				break;
-			case 'aguavberry':
-			case 'figyberry':
-			case 'iapapaberry':
-			case 'magoberry':
-			case 'wikiberry':
-				if (genNum >= 7) greatItems.push(id);
-				else poorItems.push(id);
-				break;
-			case 'berryjuice':
-				if (genNum === 2) poorItems.push(id);
-				else goodItems.push(id);
-				break;
-			case 'dragonfang':
-				if (genNum === 2) badItems.push(id);
-				else goodItems.push(id);
-				break;
-			case 'dragonscale':
-				if (genNum === 2) goodItems.push(id);
-				else badItems.push(id);
-				break;
-			case 'mail':
-				if (genNum >= 6) unreleasedItems.push(id);
-				else goodItems.push(id);
-				break;
-			// Legendaries
-			case 'adamantorb':
-			case 'griseousorb':
-			case 'lustrousorb':
-			case 'blueorb':
-			case 'redorb':
-			case 'souldew':
-			// Other
-			// fallsthrough
-			case 'stick':
-			case 'thickclub':
-			case 'lightball':
-			case 'luckypunch':
-			case 'quickpowder':
-			case 'metalpowder':
-			case 'deepseascale':
-			case 'deepseatooth':
-				specificItems.push(id);
-				break;
-			// Fling-only
-			case 'rarebone':
-			case 'belueberry':
-			case 'blukberry':
-			case 'cornnberry':
-			case 'durinberry':
-			case 'hondewberry':
-			case 'magostberry':
-			case 'nanabberry':
-			case 'nomelberry':
-			case 'pamtreberry':
-			case 'pinapberry':
-			case 'pomegberry':
-			case 'qualotberry':
-			case 'rabutaberry':
-			case 'razzberry':
-			case 'spelonberry':
-			case 'tamatoberry':
-			case 'watmelberry':
-			case 'wepearberry':
-			case 'energypowder':
-			case 'electirizer':
-			case 'oldamber':
-			case 'dawnstone':
-			case 'dubiousdisc':
-			case 'duskstone':
-			case 'firestone':
-			case 'icestone':
-			case 'leafstone':
-			case 'magmarizer':
-			case 'moonstone':
-			case 'ovalstone':
-			case 'prismscale':
-			case 'protector':
-			case 'reapercloth':
-			case 'sachet':
-			case 'shinystone':
-			case 'sunstone':
-			case 'thunderstone':
-			case 'upgrade':
-			case 'waterstone':
-			case 'whippeddream':
-			case 'bottlecap':
-			case 'goldbottlecap':
-			case 'galaricacuff':
-			case 'chippedpot':
-			case 'crackedpot':
-			case 'galaricawreath':
-				badItems.push(id);
+			case 2:
+				goodItems.push(id);
 				break;
 			// outclassed items
-			case 'aspearberry':
-			case 'bindingband':
-			case 'cheriberry':
-			case 'destinyknot':
-			case 'enigmaberry':
-			case 'floatstone':
-			case 'ironball':
-			case 'jabocaberry':
-			case 'oranberry':
-			case 'machobrace':
-			case 'pechaberry':
-			case 'persimberry':
-			case 'poweranklet':
-			case 'powerband':
-			case 'powerbelt':
-			case 'powerbracer':
-			case 'powerlens':
-			case 'powerweight':
-			case 'rawstberry':
-			case 'ringtarget':
-			case 'rowapberry':
-			case 'bigroot':
-			case 'focusband':
-			// gen 2
-			case 'psncureberry':
-			case 'przcureberry':
-			case 'burntberry':
-			case 'bitterberry':
-			case 'iceberry':
-			case 'berry':
+			case 1:
 				poorItems.push(id);
 				break;
+			// Fling-only
+			case 0:
+				badItems.push(id);
+				break;
 			default:
-				if (
-					item.name.endsWith(" Ball") || item.name.endsWith(" Fossil") || item.name.startsWith("Fossilized ") ||
-					item.name.endsWith(" Sweet") || item.name.endsWith(" Apple")
-				) {
-					badItems.push(id);
-				} else if (item.name.startsWith("TR")) {
-					badItems.push(id);
-				} else if (item.name.endsWith(" Gem") && item.name !== "Normal Gem") {
-					if (genNum >= 6) {
-						unreleasedItems.push(id);
-					} else if (item.name === "Flying Gem") {
-						greatItems.push(id);
-					} else {
-						goodItems.push(id);
-					}
-				} else if (item.name.endsWith(" Drive")) {
-					specificItems.push(id);
-				} else if (item.name.endsWith(" Memory")) {
-					specificItems.push(id);
-				} else if (item.name.startsWith("Rusted")) {
-					specificItems.push(id);
-				} else if (item.itemUser) {
-					specificItems.push(id);
-				} else if (item.megaStone) {
-					specificItems.push(id);
-				} else {
-					goodItems.push(id);
-				}
+				goodItems.push(id);
 			}
 		}
 		items.push(...greatItems);
@@ -897,7 +737,6 @@ function buildTeambuilderTables() {
 		items.push(...specificItems);
 		items.push(...poorItems);
 		items.push(...badItems);
-		items.push(...unreleasedItems);
 	}
 
 	//
@@ -1126,8 +965,9 @@ function buildTeambuilderTables() {
 
 	// Client relevant data that should be overriden by past gens and mods
 	const overrideSpeciesKeys = ['abilities', 'baseStats', 'cosmeticFormes', 'isNonstandard', 'requiredItems', 'types', 'unreleasedHidden'];
-	const overrideMoveKeys = ['accuracy', 'basePower', 'category', 'desc', 'flags', 'isNonstandard', 'noSketch', 'pp', 'priority', 'shortDesc', 'target', 'type'];
+	const overrideMoveKeys = ['accuracy', 'basePower', 'category', 'desc', 'flags', 'isNonstandard', 'noSketch', 'pp', 'priority', 'shortDesc', 'target', 'type', 'viable'];
 	const overrideAbilityKeys = ['desc', 'isNonstandard', 'rating', 'shortDesc'];
+	const overrideItemKeys = ['desc', 'isNonstandard', 'rating', 'shortDesc'];
 
 	//
 	// Past gen table
@@ -1170,7 +1010,8 @@ function buildTeambuilderTables() {
 				const baseString = JSON.stringify(baseEntry[key]);
 				if (modString !== baseString) {
 					if (!overrideDexInfo[id]) overrideDexInfo[id] = {};
-					try {
+					if (modString === undefined) overrideDexInfo[id][key] = null;
+					else try {
 						overrideDexInfo[id][key] = JSON.parse(modString);
 					} catch (e) {
 						console.log(modString + " " + id + " " + key + " parsed an invalid value: " + modString);
@@ -1179,7 +1020,6 @@ function buildTeambuilderTables() {
 				}
 			}
 		}
-		const overrideMoveKeys = ['basePower', 'accuracy', 'category', 'pp', 'isNonstandard', 'shortDesc', 'unviable'];
 		const overrideMoveInfo = {};
 		BattleTeambuilderTable[gen].overrideMoveInfo = overrideMoveInfo;
 		for (const id in genData.Moves) {
@@ -1197,27 +1037,7 @@ function buildTeambuilderTables() {
 				const baseString = JSON.stringify(baseEntry[key]);
 				if (modString !== baseString) {
 					if (!overrideMoveInfo[id]) overrideMoveInfo[id] = {};
-					overrideMoveInfo[id][key] = JSON.parse(modString);
-				}
-			}
-		}
-
-		BattleTeambuilderTable[gen].overrideMoveInfo = overrideMoveInfo;
-		for (const id in genData.Moves) {
-			const modEntry = genData.Moves[id];
-			const baseEntry = Dex.data.Moves[id];
-			if (typeof baseEntry === 'undefined') {
-				overrideMoveInfo[id] = {};
-				overrideMoveInfo[id] = modEntry;
-				overrideMoveInfo[id].exists = true;
-				continue;
-			}
-			for (const key in modEntry) {
-				if (!overrideMoveKeys.includes(key)) continue;
-				const modString = JSON.stringify(modEntry[key]);
-				const baseString = JSON.stringify(baseEntry[key]);
-				if (modString !== baseString) {
-					if (!overrideMoveInfo[id]) overrideMoveInfo[id] = {};
+					if (modString === undefined) overrideMoveInfo[id][key] = null;
 					overrideMoveInfo[id][key] = JSON.parse(modString);
 				}
 			}
@@ -1236,13 +1056,21 @@ function buildTeambuilderTables() {
 			}
 		}
 
-		const overrideItemDesc = {};
-		BattleTeambuilderTable[gen].overrideItemDesc = overrideItemDesc;
+		const overrideItemInfo = {};
+		BattleTeambuilderTable[gen].overrideItemInfo = overrideItemInfo;
 		for (const id in genData.Items) {
 			const curEntry = genDex.items.get(id);
 			const nextEntry = nextGenDex.items.get(id);
-			if ((curEntry.shortDesc || curEntry.desc) !== (nextEntry.shortDesc || nextEntry.desc)) {
-				overrideItemDesc[id] = (curEntry.shortDesc || curEntry.desc);
+			for (const key in curEntry) {
+				if (!overrideItemKeys.includes(key)) continue;
+				const curString = JSON.stringify(curEntry[key]);
+				const nextString = JSON.stringify(nextEntry[key]);
+				if (curString !== nextString) {
+					if (!overrideItemInfo[id]) overrideItemInfo[id] = {};
+					if (curString === undefined) overrideItemInfo[id][key] = null;
+					else overrideItemInfo[id][key] = JSON.parse(curString);
+					if(key === 'desc' && !curEntry['shortDesc']) overrideItemInfo[id]['shortDesc'] = JSON.parse(curString);
+				}
 			}
 		}
 
@@ -1318,14 +1146,30 @@ function buildTeambuilderTables() {
 				format.unbans = [];
 				if (!!format.banlist) {
 					for (const name of format.banlist) {
-						const id = toID(name);
+						let id = toID(name);
+						if(name.endsWith('-Base')) id = id.substr(0, id.length - 4);
 						if (id in Dex.data.Pokedex || id in modData.Pokedex) format.bans.push(id);
+						const formes = modData.Pokedex[id]?.otherFormes;
+						if(formes && toID(name) === id){ //id wasn't modified for base forme ban, therefore all formes are banned
+							for(const forme of formes){
+								const formeid = toID(forme);
+								if (formeid in Dex.data.Pokedex || formeid in modData.Pokedex) format.bans.push(formeid);
+							}
+						}
 					}
 					if (!!format.banlist && format.banlist.includes("All Pokemon")) {
 						format.bans.push('All Pokemon');
 						for (const name of format.unbanlist) {
-							const id = toID(name);
+							let id = toID(name);
+							if(name.endsWith('-Base')) id = id.substr(0, id.length - 4);
 							if (id in Dex.data.Pokedex || id in modData.Pokedex) format.unbans.push(id);
+							const formes = modData.Pokedex[id]?.otherFormes;
+							if(formes && toID(name) === id){ //id wasn't modified for base forme ban, therefore all formes are banned
+								for(const forme of formes){
+									const formeid = toID(forme);
+									if (formeid in Dex.data.Pokedex || formeid in modData.Pokedex) format.unbans.push(formeid);
+								}
+							}
 						}
 					}
 				}
@@ -1451,7 +1295,7 @@ function buildTeambuilderTables() {
 				for (const moveid in learnset) {
 					const newLearnsetEntry = getLearnsetStr(moveid, learnset[moveid], id, modConfigId);
 					let baseLearnsetEntry = learnsets[id][moveid];
-					if (modGen === '2' || modGen === '1') baseLearnsetEntry = G2Learnsets[id][moveid];
+					if (modGen <= 2 && G2Learnsets[id]) baseLearnsetEntry = G2Learnsets[id][moveid];
 					const baseLsetNoEarlyGen = baseLearnsetEntry ? baseLearnsetEntry.replace(1, '').replace(2, '') : '';
 					if (newLearnsetEntry !== baseLearnsetEntry && newLearnsetEntry !== baseLsetNoEarlyGen) {
 						if (!overrideLearnsets[id]) overrideLearnsets[id] = {};
@@ -1465,32 +1309,89 @@ function buildTeambuilderTables() {
 					}
 				}
 			}
-			//items
+			//items			
 			let items = [];
 			const fullItemName = {};
 			BattleTeambuilderTable[modConfigId].fullItemName = fullItemName;
 			BattleTeambuilderTable[modConfigId].items = items;
-			const overrideItemDesc = {};
-			BattleTeambuilderTable[modConfigId].overrideItemDesc = overrideItemDesc;
-			items.push(BattleTeambuilderTable.items[0]);
+			const overrideItemInfo = {};
+			BattleTeambuilderTable[modConfigId].overrideItemInfo = overrideItemInfo;
+
+			const greatItems = [];
+			const goodItems = [];
+			const specificItems = [];
+			const poorItems = [];
+			const badItems = [];
 			for (const id in modData.Items) {
 				const modEntry = modData.Items[id];
 				const baseEntry = Dex.data.Items[id];
-				const fakeItem = (typeof baseEntry === 'undefined');
-				if (fakeItem) {
-					items.push(id);
+				if (typeof baseEntry === 'undefined') {
+					overrideItemInfo[id] = {};
+					overrideItemInfo[id] = modEntry;
+					overrideItemInfo[id].exists = true;
 					fullItemName[id] = modData.Items[id].name;
+				} else {
+					if(baseEntry.gen > modGen) continue;
+					for (const key in modEntry) {
+						if (!overrideItemKeys.includes(key)) continue;
+						const modString = JSON.stringify(modEntry[key]);
+						const baseString = JSON.stringify(baseEntry[key]);
+						if (modString !== baseString) {
+							if (!overrideItemInfo[id]) overrideItemInfo[id] = {};
+							overrideItemInfo[id][key] = JSON.parse(modString);
+							if(key === 'desc' && !modEntry['shortDesc']) overrideItemInfo[id]['shortDesc'] = JSON.parse(modString);
+						}
+					}
 				}
-				if (fakeItem || (modEntry.shortDesc || modEntry.desc) !== (baseEntry.shortDesc || baseEntry.desc)) {
-					overrideItemDesc[id] = (modEntry.shortDesc || modEntry.desc);
+				
+				if(modEntry.itemUser || modEntry.megaStone || id === 'boosterenergy'){
+					specificItems.push(id);
+					continue;
+				}
+				if(modEntry.isPokeball || modEntry.name.startsWith("TR")){
+					badItems.push(id);
+					continue;
+				}
+				switch (modEntry.rating) {
+				case 3:
+					greatItems.push(id);
+					break;
+				case 2:
+					goodItems.push(id);
+					break;
+				// outclassed items
+				case 1:
+					poorItems.push(id);
+					break;
+				// Fling-only
+				case 0:
+					badItems.push(id);
+					break;
+				// Allows mods to manually set Pokemon-specific items
+				case -1:
+					specificItems.push(id);
+					break;
+				default:
+					goodItems.push(id);
 				}
 			}
-			let itemTable = BattleTeambuilderTable.items;
-			modGen === 9 ? itemTable = BattleTeambuilderTable.items : itemTable = BattleTeambuilderTable['gen' + modGen].items;
-			items.push(...itemTable.slice(1));
+			greatItems.sort();
+			greatItems.unshift(['header', "Popular items"]);
+			items.push(...greatItems);
+			goodItems.sort();
+			goodItems.unshift(['header', "Items"]);
+			items.push(...goodItems);
+			specificItems.sort();
+			specificItems.unshift(['header', "Pok&eacute;mon-specific items"]);
+			items.push(...specificItems);
+			poorItems.sort();
+			poorItems.unshift(['header', "Usually useless items"]);
+			items.push(...poorItems);
+			badItems.sort();
+			badItems.unshift(['header', "Useless items"]);
+			items.push(...badItems);
 			//moves
 			const overrideMoveInfo = {};
-			const overrideMoveKeys = ['basePower', 'accuracy', 'category', 'pp', 'isNonstandard', 'shortDesc', 'type', 'unviable', 'isViable'];
 			BattleTeambuilderTable[modConfigId].overrideMoveInfo = overrideMoveInfo;
 			for (const id in modData.Moves) {
 				const modEntry = modData.Moves[id];
@@ -1520,6 +1421,15 @@ function buildTeambuilderTables() {
 					}
 				}
 				if (overrideMoveInfo[id] && moddedMoveIsOldGen) overrideMoveInfo[id].modMoveFromOldGen = true;
+			}
+			for(const id in Dex.data.Moves){ //Weed out nulled moves
+				const modEntry = modData.Moves[id];
+				if(!modEntry){
+					overrideMoveInfo[id] = {};
+					overrideMoveInfo[id].isNonstandard = "Unobtainable";
+					overrideMoveInfo[id].exists = false;
+					continue;
+				}
 			}
 			//abilities
 			const fullAbilityName = {};

--- a/src/battle-dex-data.ts
+++ b/src/battle-dex-data.ts
@@ -1046,6 +1046,7 @@ class Item implements Effect {
 	readonly id: ID;
 	readonly name: string;
 	readonly gen: number;
+	readonly isNonstandard: string;
 	readonly exists: boolean;
 
 	readonly num: number;
@@ -1073,6 +1074,7 @@ class Item implements Effect {
 		this.name = Dex.sanitizeName(name);
 		this.id = id;
 		this.gen = data.gen || 0;
+		this.isNonstandard = data.isNonstandard || undefined;
 		this.exists = ('exists' in data ? !!data.exists : true);
 
 		this.num = data.num || 0;

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -306,8 +306,8 @@ const Dex = new class implements ModdedDex {
 					basePower: Number(id.slice(11)),
 				};
 			}
-
 			if (!data) data = {exists: false};
+			
 			let move = new Move(id, name, data);
 			window.BattleMovedex[id] = move;
 			return move;
@@ -974,14 +974,14 @@ class ModdedDex {
 				data.name = table.fullItemName[id];
 				data.exists = true;
 			}
-			if (id in table.overrideItemDesc) data.shortDesc = table.overrideItemDesc[id];
-	
-			for (let i = this.gen; i < 9; i++) {
-				const table = window.BattleTeambuilderTable['gen' + i];
-				if (table.overrideItemDesc && id in table.overrideItemDesc) {
-					data.shortDesc = table.overrideItemDesc[id];
-					break;
+			for(let i = 9; i > this.gen; i--) {
+				const genTable = window.BattleTeambuilderTable['gen' + (i-1)];
+				if (genTable.overrideItemInfo[id]) {
+					data = {...Dex.items.get(name), ...genTable.overrideItemInfo[id]};
 				}
+			}
+			if (this.modid && table.overrideItemInfo[id]) {
+				data = {...Dex.items.get(name), ...table.overrideItemInfo[id]};
 			}
 
 			const item = new Item(id, name, data);


### PR DESCRIPTION
Item features (will be proposing these to main):
- Ratings: Mods can define whether an item is Popular, regular, usually useless, useless, or Pokemon-specific
-- All custom Mega Stones and items with an itemUser defined default to Pokemon-specific like the real items do
-- (minor) Booster Energy is now classified as specific to Paradox Pokemon
- Individual mod isNonstandard changes now display in teambuilder

Move useful/useless:
- The short and easy way: Adding viable: true/false to a move will force it to be one or the other. If not present, it defaults to the usual algorithm.
- The long and thorough way: Mods can now add their own version of the moveIsNotUseless function (and the four tables it uses, if desired) to their teambuilderConfig. After the normal function is run, the mod's version will be, and it will override only if it returns a value for that move.

Fixes:
- Sketch properly includes a mod's new and removed moves and can follow the same usefulness features
- Script-altered Uber additions now reflect the bans on alternate formes in Pokemon selection
- Gen 1 tradebacks correctly appear when searching Pokemon by move.

I tested the hell out of this in mods of as many types as should be affected (ones with Megas, National Dex mods, past gen mods, Gen 2 Doubles since it acts uniquely, and of course Earth & Sky since it makes changes for everything under the sun), including after transferring and pushing the changes on the DH side.