### PR TITLE
Node recs and further move viability improvements

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -705,11 +705,11 @@ function buildTeambuilderTables() {
 				const banlist = Dex.formats.getRuleTable(Dex.formats.get(gen + 'metronomebattle'));
 				if (banlist.isBanned('item:' + item.id)) continue;
 			}
-			if(item.itemUser || item.megaStone || id === 'boosterenergy'){
+			if (item.itemUser || item.megaStone || id === 'boosterenergy') {
 				specificItems.push(id);
 				continue;
 			}
-			if(item.isPokeball || item.name.startsWith("TR")){
+			if (item.isPokeball || item.name.startsWith("TR")) {
 				badItems.push(id);
 				continue;
 			}
@@ -1039,7 +1039,7 @@ function buildTeambuilderTables() {
 				const baseString = JSON.stringify(baseEntry[key]);
 				if (modString !== baseString) {
 					if (!overrideMoveInfo[id]) overrideMoveInfo[id] = {};
-					if (modString === undefined) overrideMoveInfo[id][key] = null;
+					//if (modString === undefined) overrideMoveInfo[id][key] = null;
 					overrideMoveInfo[id][key] = JSON.parse(modString);
 				}
 			}
@@ -1346,11 +1346,11 @@ function buildTeambuilderTables() {
 					}
 				}
 				
-				if(modEntry.itemUser || modEntry.megaStone || id === 'boosterenergy'){
+				if (modEntry.itemUser || modEntry.megaStone || id === 'boosterenergy') {
 					specificItems.push(id);
 					continue;
 				}
-				if(modEntry.isPokeball || modEntry.name.startsWith("TR")){
+				if (modEntry.isPokeball || modEntry.name.startsWith("TR")) {
 					badItems.push(id);
 					continue;
 				}

--- a/src/battle-dex-data.ts
+++ b/src/battle-dex-data.ts
@@ -1186,6 +1186,7 @@ class Move implements Effect {
 	readonly desc: string;
 	readonly shortDesc: string;
 	readonly isNonstandard: string | null;
+	readonly viable: boolean | null;
 	readonly isZ: ID;
 	readonly zMove?: {
 		basePower?: number,
@@ -1194,7 +1195,7 @@ class Move implements Effect {
 	};
 	readonly isMax: boolean | string;
 	readonly maxMove: {basePower: number};
-	readonly ohko: true | 'Ice' | null;
+	readonly ohko: true | TypeName | null;
 	readonly recoil: number[] | null;
 	readonly heal: number[] | null;
 	readonly multihit: number[] | number | null;
@@ -1227,6 +1228,7 @@ class Move implements Effect {
 		this.desc = data.desc;
 		this.shortDesc = data.shortDesc;
 		this.isNonstandard = data.isNonstandard || null;
+		this.viable = ('viable' in data ? !!data.viable : null);
 		this.isZ = data.isZ || '';
 		this.zMove = data.zMove || {};
 		this.ohko = data.ohko || null;

--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -1360,8 +1360,8 @@ class BattleItemSearch extends BattleTypedSearch<'item'> {
 			if (row[0] !== 'item') continue;
 			const id = row[1];
 			let item = this.dex.items.get(id);
-			if (!item.exists || item.isNonstandard){
-				if(item.isNonstandard != "Past" || this.formatType != "natdex"){
+			if (!item.exists || item.isNonstandard) {
+				if (item.isNonstandard !== "Past" || this.formatType !== 'natdex') {
 					results.splice(i, 1);
 					continue;
 				}
@@ -1469,22 +1469,6 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 				switch (id) {
 				case 'fly': return !moves.includes('drillpeck');
 				case 'dig': return !moves.includes('earthquake');
-				}
-			}
-			// KEP Integrations. This acts as a "correctional" patch.
-			if (this.mod === 'gen1expansionpack') {
-				if (['bulletpunch', 'irondefense', 'ironhead', 'metalsound', 'drainingkiss', 'charm'].includes(id)) return true;
-				if (['magnetbomb', 'disarmingvoice', 'brutalswing'].includes(id)) return false;
-				switch (id) {
-					// steel hierarchy
-					case 'smartstrike': return !moves.includes('ironhead');
-					case 'magnetbomb': return !moves.includes('ironhead') && !moves.includes('smartstrike');
-					case 'mirrorshot': return !moves.includes('ironhead') && !moves.includes('smartstrike') && !moves.includes('magnetbomb');
-					// dark hierarchy
-					case 'kowtowcleave': return !moves.includes('nightslash');
-					case 'falsesurrender': return !moves.includes('kowtowcleave') && !moves.includes('nightslash');
-					case 'feintattack': return !moves.includes('kowtowcleave') && !moves.includes('falsesurrender') && !moves.includes('nightslash');
-					case 'brutalswing': return !moves.includes('kowtowcleave') && !moves.includes('falsesurrender') && !moves.includes('nightslash') && !moves.includes('feintattack');
 				}
 			}
 		}
@@ -1641,9 +1625,10 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 		if (this.formatType === 'doubles' && BattleMoveSearch.GOOD_DOUBLES_MOVES.includes(id)) {
 			return true;
 		}
-		const moveData = BattleMovedex[id];
+		const moveData = dex.moves.get(id);
 		if (!moveData) return true;
 		if (moveData.category === 'Status') {
+			if (!BattleMovedex[id].exists) return true; //Flag custom moves as viable by default
 			return BattleMoveSearch.GOOD_STATUS_MOVES.includes(id);
 		}
 		if (moveData.flags?.charge) {
@@ -1655,7 +1640,7 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 		if (moveData.flags?.slicing && abilityid === 'sharpness') {
 			return true;
 		}
-		if (moveData.basePower < 75) {
+		if (moveData.basePower < 75 && !(abilityid === 'technician' && moveData.basePower >= 50)) {
 			return BattleMoveSearch.GOOD_WEAK_MOVES.includes(id);
 		}
 		return !BattleMoveSearch.BAD_STRONG_MOVES.includes(id);
@@ -1841,9 +1826,9 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 		let uselessMoves: SearchRow[] = [];
 		for (const id of moves) {
 			let isUsable = this.moveIsNotUseless(id as ID, species, moves, this.set);
-			if(hasOwnUsefulCheck){
-				const modIsUsable = window.ModConfig[this.mod].moveIsNotUseless.apply(window.ModConfig[this.mod], [id as ID, species, moves, this.set]);
-				if(typeof modIsUsable === 'boolean' && modIsUsable !== isUsable) isUsable = modIsUsable;
+			if (hasOwnUsefulCheck) {
+				const modIsUsable = window.ModConfig[this.mod].moveIsNotUseless.apply(window.ModConfig[this.mod], [id as ID, species, moves, this.set, this.dex]);
+				if (typeof modIsUsable === 'boolean' && modIsUsable !== isUsable) isUsable = modIsUsable;
 			}
 			if (isUsable) {
 				if (!usableMoves.length) usableMoves.push(['header', "Moves"]);
@@ -1859,9 +1844,9 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 		}
 		for (const id of sketchMoves) {
 			let isUsable = this.moveIsNotUseless(id as ID, species, sketchMoves, this.set);
-			if(hasOwnUsefulCheck){
-				const modIsUsable = window.ModConfig[this.mod].moveIsNotUseless.apply(window.ModConfig[this.mod], [id as ID, species, moves, this.set]);
-				if(typeof modIsUsable === 'boolean' && modIsUsable !== isUsable) isUsable = modIsUsable;
+			if (hasOwnUsefulCheck) {
+				const modIsUsable = window.ModConfig[this.mod].moveIsNotUseless.apply(window.ModConfig[this.mod], [id as ID, species, moves, this.set, this.dex]);
+				if (typeof modIsUsable === 'boolean' && modIsUsable !== isUsable) isUsable = modIsUsable;
 			}
 			if (isUsable) {
 				usableMoves.push(['move', id as ID]);

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -974,14 +974,14 @@ class ModdedDex {
 				data.name = table.fullItemName[id];
 				data.exists = true;
 			}
-			for(let i = 9; i > this.gen; i--) {
-				const genTable = window.BattleTeambuilderTable['gen' + (i-1)];
+			for(let i = Dex.gen - 1; i >= this.gen; i--) {
+				const genTable = window.BattleTeambuilderTable[`gen${i}`];
 				if (genTable.overrideItemInfo[id]) {
-					data = {...Dex.items.get(name), ...genTable.overrideItemInfo[id]};
+					Object.assign(data, table.overrideItemInfo[id]);
 				}
 			}
-			if (this.modid && table.overrideItemInfo[id]) {
-				data = {...Dex.items.get(name), ...table.overrideItemInfo[id]};
+			if (this.modid !== `gen${this.gen}` && table.overrideItemInfo[id]) {
+					Object.assign(data, table.overrideItemInfo[id]);
 			}
 
 			const item = new Item(id, name, data);


### PR DESCRIPTION
Make sure to merge at the same time as the [server PR](https://github.com/scoopapa/DH2/pull/163), or it'll break KEP's teambuilder setup.

Custom status moves are set as viable by default now, since that was a concern of Scoop's. Damaging moves continue to use the algorithm.