### PR TITLE
Fix Old Gens Non-Fairies Type Overriding

### DIFF
--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -1336,7 +1336,7 @@
 			buf += '</div>';
 			buf += '<div class="setcell setcell-typeicons">';
 			var types = species.types;
-			var table = (this.curTeam.gen < 7 ? BattleTeambuilderTable['gen' + this.curTeam.gen] : null);
+			var table = BattleTeambuilderTable(this.curTeam.mod);
 			if (
 				table && table.overrideDexInfo && species.id in table.overrideDexInfo &&
 				table.overrideDexInfo[species.id].types


### PR DESCRIPTION
Apparently this fixes a teambuilder bug where Pokemon like Clefable, Wigglytuff, Togetic etc. will show their old gens type in the teambuilder instead of their mod type due to Fairy gens or something (according to Yak Attack).