### PR TITLE
Teambuilder: Fix Hidden Power Selection & Validation

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -1310,7 +1310,7 @@ function buildTeambuilderTables() {
 			BattleTeambuilderTable[modConfigId].formatSlices = formatSlices;
 			const doublesFormatSlices = {};
 			if (hasDoublesFormats) BattleTeambuilderTable[modConfigId].doubles.formatSlices = doublesFormatSlices;
-			const tierOrder = ["OU", "AG", "Uber", "(Uber)", "OU", "(OU)", "UUBL", "UU", "RUBL", "RU", "NUBL", "NU", "PUBL", "PU", "(PU)", "New", "NFE", "LC Uber", "LC", "Unreleased"];
+			const tierOrder = ["OU", "AG", "Uber", "(Uber)", "OU", "(OU)", "UUBL", "UU", "RUBL", "RU", "NUBL", "NU", "PUBL", "PU", "(PU)", "ZUBL", "ZU", "New", "NFE", "LC Uber", "LC", "Unreleased"];
 			const tierOrderDoubles = ["DUber", "(DUber)", "DOU", "DBL", "(DOU)", "DUU", "(DUU)", "New", "NFE", "LC Uber", "LC"];
 			if (hasSinglesFormats) buildTiers(modConfigId, tierTable, tiers, customTiers, formatSlices, tierOrder);
 			if (hasDoublesFormats) buildTiers(modConfigId, tierTable, doublesTiers, customDoublesTiers, doublesFormatSlices, tierOrderDoubles);

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -3295,13 +3295,13 @@
 					set.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 					if (this.curTeam.gen > 2) {
 						var HPivs = this.curTeam.dex.types.get(hpType).HPivs;
-						for (var i in exports.BattleTypeChart[hpType].HPivs) {
-							set.ivs[i] = exports.BattleTypeChart[hpType].HPivs[i];
+						for (var i in HPivs) {
+							set.ivs[i] = HPivs[i];
 						}
 					} else {
 						var HPdvs = this.curTeam.dex.types.get(hpType).HPdvs;
-						for (var i in exports.BattleTypeChart[hpType].HPdvs) {
-							set.ivs[i] = exports.BattleTypeChart[hpType].HPdvs[i] * 2;
+						for (var i in HPdvs) {
+							set.ivs[i] = HPdvs[i] * 2;
 						}
 						var atkDV = Math.floor(set.ivs.atk / 2);
 						var defDV = Math.floor(set.ivs.def / 2);

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -3290,16 +3290,13 @@
 			if (resetSpeed) minSpe = false;
 			if (moveName.substr(0, 13) === 'Hidden Power ') {
 				if (!this.canHyperTrain(set)) {
-					var hpType = moveName.substr(13);
-
+					var hpType = moveName.substr(13).toLowerCase();
 					set.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 					if (this.curTeam.gen > 2) {
-						var HPivs = this.curTeam.dex.types.get(hpType).HPivs;
 						for (var i in exports.BattleTypeChart[hpType].HPivs) {
 							set.ivs[i] = exports.BattleTypeChart[hpType].HPivs[i];
 						}
 					} else {
-						var HPdvs = this.curTeam.dex.types.get(hpType).HPdvs;
 						for (var i in exports.BattleTypeChart[hpType].HPdvs) {
 							set.ivs[i] = exports.BattleTypeChart[hpType].HPdvs[i] * 2;
 						}

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -3295,13 +3295,13 @@
 					set.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 					if (this.curTeam.gen > 2) {
 						var HPivs = this.curTeam.dex.types.get(hpType).HPivs;
-						for (var i in HPivs) {
-							set.ivs[i] = HPivs[i];
+						for (var i in exports.BattleTypeChart[hpType].HPivs) {
+							set.ivs[i] = exports.BattleTypeChart[hpType].HPivs[i];
 						}
 					} else {
 						var HPdvs = this.curTeam.dex.types.get(hpType).HPdvs;
-						for (var i in HPdvs) {
-							set.ivs[i] = HPdvs[i] * 2;
+						for (var i in exports.BattleTypeChart[hpType].HPdvs) {
+							set.ivs[i] = exports.BattleTypeChart[hpType].HPdvs[i] * 2;
 						}
 						var atkDV = Math.floor(set.ivs.atk / 2);
 						var defDV = Math.floor(set.ivs.def / 2);

--- a/play.pokemonshowdown.com/js/storage.js
+++ b/play.pokemonshowdown.com/js/storage.js
@@ -1368,11 +1368,11 @@ Storage.importTeam = function (buffer, teams) {
 			if (line.substr(0, 14) === 'Hidden Power [') {
 				var hptype = line.substr(14, line.length - 15);
 				line = 'Hidden Power ' + hptype;
-				var type = Dex.types.get(hptype.toLowerCase());
-				if (!curSet.ivs && window.BattleTypeChart && window.BattleTypeChart[type]) {
+				var type = Dex.types.get(hptype);
+				if (!curSet.ivs && type) {
 					curSet.ivs = {};
-					for (var stat in window.BattleTypeChart[type].HPivs) {
-						curSet.ivs[stat] = window.BattleTypeChart[type].HPivs[stat];
+					for (var stat in type.HPivs) {
+						curSet.ivs[stat] = type.HPivs[stat];
 					}
 				}
 			}

--- a/play.pokemonshowdown.com/js/storage.js
+++ b/play.pokemonshowdown.com/js/storage.js
@@ -888,7 +888,15 @@ Storage.fastUnpackTeam = function (buf) {
 	while (true) {
 		var set = {};
 		team.push(set);
-
+		
+		var thisDex = Dex;
+		for (var teamid in this.teams) {
+			var teamData = this.teams[teamid];
+			if (teamData.team === buf && teamData.mod) {
+				thisDex = Dex.mod(teamData.mod);
+			}
+		}
+		
 		// name
 		j = buf.indexOf('|', i);
 		set.name = buf.substring(i, j);
@@ -907,7 +915,7 @@ Storage.fastUnpackTeam = function (buf) {
 		// ability
 		j = buf.indexOf('|', i);
 		var ability = buf.substring(i, j);
-		var species = Dex.species.get(set.species);
+		var species = thisDex.species.get(set.species);
 		if (species.baseSpecies === 'Zygarde' && ability === 'H') ability = 'Power Construct';
 		set.ability = (species.abilities && ['', '0', '1', 'H', 'S'].includes(ability) ? species.abilities[ability] || '!!!ERROR!!!' : ability);
 		i = j + 1;
@@ -999,6 +1007,14 @@ Storage.fastUnpackTeam = function (buf) {
 Storage.unpackTeam = function (buf) {
 	if (!buf) return [];
 
+	var thisDex = Dex;
+	for (var teamid in this.teams) {
+		var teamData = this.teams[teamid];
+		if (teamData.team === buf && teamData.mod) {
+			thisDex = Dex.mod(teamData.mod);
+		}
+	}
+
 	var team = [];
 	var i = 0, j = 0;
 
@@ -1013,25 +1029,25 @@ Storage.unpackTeam = function (buf) {
 
 		// species
 		j = buf.indexOf('|', i);
-		set.species = Dex.species.get(buf.substring(i, j)).name || set.name;
+		set.species = thisDex.species.get(buf.substring(i, j)).name || set.name;
 		i = j + 1;
 
 		// item
 		j = buf.indexOf('|', i);
-		set.item = Dex.items.get(buf.substring(i, j)).name;
+		set.item = thisDex.items.get(buf.substring(i, j)).name;
 		i = j + 1;
 
 		// ability
 		j = buf.indexOf('|', i);
-		var ability = Dex.abilities.get(buf.substring(i, j)).name;
-		var species = Dex.species.get(set.species);
+		var ability = thisDex.abilities.get(buf.substring(i, j)).name;
+		var species = thisDex.species.get(set.species);
 		set.ability = (species.abilities && ability in {'':1, 0:1, 1:1, H:1} ? species.abilities[ability || '0'] : ability);
 		i = j + 1;
 
 		// moves
 		j = buf.indexOf('|', i);
 		set.moves = buf.substring(i, j).split(',').map(function (moveid) {
-			return Dex.moves.get(moveid).name;
+			return thisDex.moves.get(moveid).name;
 		});
 		i = j + 1;
 
@@ -1197,6 +1213,7 @@ Storage.importTeam = function (buffer, teams) {
 	} else if (text.length === 1 || (text.length === 2 && !text[1])) {
 		return Storage.unpackTeam(text[0]);
 	}
+	const mod = (window.room.curTeam && window.room.curTeam.mod) ? window.room.curTeam.mod : "";
 	for (var i = 0; i < text.length; i++) {
 		var line = $.trim(text[i]);
 		if (line === '' || line === '---') {
@@ -1258,11 +1275,29 @@ Storage.importTeam = function (buffer, teams) {
 			var parenIndex = line.lastIndexOf(' (');
 			if (line.substr(line.length - 1) === ')' && parenIndex !== -1) {
 				line = line.substr(0, line.length - 1);
-				curSet.species = Dex.species.get(line.substr(parenIndex + 2)).name;
+				var thisDex = Dex.species.get(line.substr(parenIndex + 2)).exists ? Dex : null;
+				if (!thisDex) {
+					for (var modid in (ModConfig)) {
+						if (Dex.mod(modid).species.get(line.substr(parenIndex + 2)).exists) {
+							thisDex = Dex.mod(modid);
+						}
+					}
+				}
+				curSet.species = thisDex.species.get(line.substr(parenIndex + 2)).name;
 				line = line.substr(0, parenIndex);
 				curSet.name = line;
 			} else {
-				curSet.species = Dex.species.get(line).name;
+				var thisDex = Dex.species.get(line).exists ? Dex : null;
+				if (!thisDex) {
+					for (var modid in (ModConfig)) {
+						if (Dex.mod(modid).species.get(line).exists) {
+							thisDex = Dex.mod(modid);
+						}
+					}
+				}
+				console.log(curSet);
+				console.log(line);
+				curSet.species = thisDex.species.get(line).name;
 				curSet.name = '';
 			}
 		} else if (line.substr(0, 7) === 'Trait: ') {
@@ -1333,11 +1368,11 @@ Storage.importTeam = function (buffer, teams) {
 			if (line.substr(0, 14) === 'Hidden Power [') {
 				var hptype = line.substr(14, line.length - 15);
 				line = 'Hidden Power ' + hptype;
-				var type = Dex.types.get(hptype);
-				if (!curSet.ivs && type) {
+				var type = Dex.types.get(hptype.toLowerCase());
+				if (!curSet.ivs && window.BattleTypeChart && window.BattleTypeChart[type]) {
 					curSet.ivs = {};
-					for (var stat in type.HPivs) {
-						curSet.ivs[stat] = type.HPivs[stat];
+					for (var stat in window.BattleTypeChart[type].HPivs) {
+						curSet.ivs[stat] = window.BattleTypeChart[type].HPivs[stat];
 					}
 				}
 			}

--- a/play.pokemonshowdown.com/js/storage.js
+++ b/play.pokemonshowdown.com/js/storage.js
@@ -1491,6 +1491,7 @@ Storage.exportTeam = function (team, gen, hidestats) {
 						}
 						for (var stat in BattleStatNames) {
 							if ((curSet.ivs[stat] === undefined ? 31 : curSet.ivs[stat]) !== (Dex.types.get(hpType).HPivs[stat] || 31)) {
+								defaultIvs = false;
 								break;
 							}
 						}

--- a/play.pokemonshowdown.com/js/storage.js
+++ b/play.pokemonshowdown.com/js/storage.js
@@ -1368,7 +1368,7 @@ Storage.importTeam = function (buffer, teams) {
 			if (line.substr(0, 14) === 'Hidden Power [') {
 				var hptype = line.substr(14, line.length - 15);
 				line = 'Hidden Power ' + hptype;
-				var type = Dex.types.get(hptype).toLowerCase;
+				var type = Dex.types.get(hptype.toLowerCase());
 				if (!curSet.ivs && window.BattleTypeChart && window.BattleTypeChart[type]) {
 					curSet.ivs = {};
 					for (var stat in window.BattleTypeChart[type].HPivs) {

--- a/play.pokemonshowdown.com/js/storage.js
+++ b/play.pokemonshowdown.com/js/storage.js
@@ -1368,11 +1368,11 @@ Storage.importTeam = function (buffer, teams) {
 			if (line.substr(0, 14) === 'Hidden Power [') {
 				var hptype = line.substr(14, line.length - 15);
 				line = 'Hidden Power ' + hptype;
-				var type = Dex.types.get(hptype);
-				if (!curSet.ivs && window.BattleTypeChart && window.BattleTypeChart[hptype]) {
+				var type = Dex.types.get(hptype).toLowerCase;
+				if (!curSet.ivs && window.BattleTypeChart && window.BattleTypeChart[type]) {
 					curSet.ivs = {};
-					for (var stat in window.BattleTypeChart[hptype].HPivs) {
-						curSet.ivs[stat] = window.BattleTypeChart[hptype].HPivs[stat];
+					for (var stat in window.BattleTypeChart[type].HPivs) {
+						curSet.ivs[stat] = window.BattleTypeChart[type].HPivs[stat];
 					}
 				}
 			}


### PR DESCRIPTION
It was using something from the stone age I think LOL. Updated so that we don't need to manually adjust DVs in gen 2 mods when choosing a hidden power type.