### PR TITLE
ACTUALLY fix that “ZUBL not excluded” bug

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -1142,7 +1142,7 @@ function buildTeambuilderTables() {
 			}
 		}
 	}
-	const sliceTiers = ["OU", "AG", "Uber", "UU", "(UU)", "RU", "NU", "(NU)", "PU", "(PU)", "ZUBL", "ZU", "NFE", "LC", "DOU", "DUU", "(DUU)", "New", "Legal", "Regular", "Restricted Legendary", "CAP LC"];
+	const sliceTiers = ["OU", "AG", "Uber", "UU", "(UU)", "RU", "NU", "(NU)", "PU", "(PU)",  "ZU", "NFE", "LC", "DOU", "DUU", "(DUU)", "New", "Legal", "Regular", "Restricted Legendary", "CAP LC"];
 	function buildTiers(modid, tierTable, tiers, customTiers, formatSlices, tierOrder) {
 		for (const tier of tierOrder) {
 			if (ModConfig[modid].excludeStandardTiers) break;
@@ -1230,7 +1230,7 @@ function buildTeambuilderTables() {
 			}
 			// Find any nonstandard tiers used by this mod
 			const standardTiers = ['uber', 'ou', 'uubl', 'uu', 'rubl', 'ru', 'nubl', 'nu', 'publ',
-				'pu', 'zu', 'nfe', 'lcuber', 'lc', 'cap', 'caplc', 'capnfe', 'ag', 'duber', 'dou',
+				'pu', 'zubl', 'zu', 'nfe', 'lcuber', 'lc', 'cap', 'caplc', 'capnfe', 'ag', 'duber', 'dou',
 				'dbl', 'duu', 'dnu', 'illegal', 'unreleased'];
 			if (!ModConfig[modConfigId].customTiers) ModConfig[modConfigId].customTiers = [];
 			if (!ModConfig[modConfigId].customDoublesTiers) ModConfig[modConfigId].customDoublesTiers = [];


### PR DESCRIPTION
I appreciate the effort but that bug is still around and when I edited it into standardTiers that is what fixed it, reason I’m excluding it from SliceTiers is primarily for consistency with the other BL tiers