### PR TITLE
Vaporemons Tooltips for Paradox Abilities and some items + Healing Stones show up

### DIFF
--- a/play.pokemonshowdown.com/src/battle-animations.ts
+++ b/play.pokemonshowdown.com/src/battle-animations.ts
@@ -1266,6 +1266,38 @@ export class BattleScene implements BattleSceneStub {
 			this.$spritesFront[spriteIndex].append(surge3.$el!);
 			this.sideConditions[siden][id] = [surge1, surge2, surge3];
 			break;
+		//Vaporemons
+		case 'healingstones':
+			const hstone1 = new Sprite(BattleEffects.greenmetal1, {
+				display: 'block',
+				x: x + side.leftof(-30),
+				y: y - 20,
+				z: side.z,
+				opacity: 0.5,
+				scale: 0.8,
+			}, this);
+			const hstone2 = new Sprite(BattleEffects.greenmetal2, {
+				display: 'block',
+				x: x + side.leftof(35),
+				y: y - 15,
+				z: side.z,
+				opacity: 0.5,
+				scale: 0.8,
+			}, this);
+			const hstone3 = new Sprite(BattleEffects.greenmetal1, {
+				display: 'block',
+				x: x + side.leftof(50),
+				y: y - 10,
+				z: side.z,
+				opacity: 0.5,
+				scale: 0.8,
+			}, this);
+
+			this.$spritesFront[spriteIndex].append(hstone1.$el!);
+			this.$spritesFront[spriteIndex].append(hstone2.$el!);
+			this.$spritesFront[spriteIndex].append(hstone3.$el!);
+			this.sideConditions[siden][id] = [hstone1, hstone2, hstone3];
+			break;
 		case 'spikes':
 			let spikeArray = this.sideConditions[siden]['spikes'];
 			if (!spikeArray) {
@@ -1825,6 +1857,38 @@ export class PokemonSprite extends Sprite {
 		quarkdrivespa: ['Quark Drive: SpA', 'good'],
 		quarkdrivespd: ['Quark Drive: SpD', 'good'],
 		quarkdrivespe: ['Quark Drive: Spe', 'good'],
+		//Vaporemons
+		protosmosisatk: ['Protosmosis: Atk', 'good'],
+		protosmosisdef: ['Protosmosis: Def', 'good'],
+		protosmosisspa: ['Protosmosis: SpA', 'good'],
+		protosmosisspd: ['Protosmosis: SpD', 'good'],
+		protosmosisspe: ['Protosmosis: Spe', 'good'],
+		photondriveatk: ['Photon Drive: Atk', 'good'],
+		photondrivedef: ['Photon Drive: Def', 'good'],
+		photondrivespa: ['Photon Drive: SpA', 'good'],
+		photondrivespd: ['Photon Drive: SpD', 'good'],
+		photondrivespe: ['Photon Drive: Spe', 'good'],
+		protocrysalisatk: ['Protocrysalis: Atk', 'good'],
+		protocrysalisdef: ['Protocrysalis: Def', 'good'],
+		protocrysalisspa: ['Protocrysalis: SpA', 'good'],
+		protocrysalisspd: ['Protocrysalis: SpD', 'good'],
+		protocrysalisspe: ['Protocrysalis: Spe', 'good'],
+		neurondriveatk: ['Neuron Drive: Atk', 'good'],
+		neurondrivedef: ['Neuron Drive: Def', 'good'],
+		neurondrivespa: ['Neuron Drive: SpA', 'good'],
+		neurondrivespd: ['Neuron Drive: SpD', 'good'],
+		neurondrivespe: ['Neuron Drive: Spe', 'good'],
+		protostasisatk: ['Protostasis: Atk', 'good'],
+		protostasisdef: ['Protostasis: Def', 'good'],
+		protostasisspa: ['Protostasis: SpA', 'good'],
+		protostasisspd: ['Protostasis: SpD', 'good'],
+		protostasisspe: ['Protostasis: Spe', 'good'],
+		runedriveatk: ['Rune Drive: Atk', 'good'],
+		runedrivedef: ['Rune Drive: Def', 'good'],
+		runedrivespa: ['Rune Drive: SpA', 'good'],
+		runedrivespd: ['Rune Drive: SpD', 'good'],
+		runedrivespe: ['Rune Drive: Spe', 'good'],
+		
 		fallen1: ['Fallen: 1', 'good'],
 		fallen2: ['Fallen: 2', 'good'],
 		fallen3: ['Fallen: 3', 'good'],

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -2106,9 +2106,6 @@ class BattleTooltips {
 		'Palkia': ['Lustrous Globe', 'Lustrous Orb'],
 		'Giratina': ['Griseous Core', 'Griseous Orb'],
 		'Venomicon': ['Vile Vial'],
-		
-		//Vaporemons
-		'Charizard': ['Charizardite Shard X', 'Charizardite Shard Y'],
 	};
 	static orbTypes: {[itemName: string]: TypeName[]} = {
 		'Soul Dew': ['Psychic', 'Dragon'],
@@ -2119,10 +2116,6 @@ class BattleTooltips {
 		'Griseous Core': ['Ghost', 'Dragon'],
 		'Griseous Orb': ['Ghost', 'Dragon'],
 		'Vile Vial': ['Poison', 'Flying'],
-		
-		//Vaporemons
-		'Charizardite Shard X': ['Fire', 'Dragon'],
-		'Charizardite Shard Y': ['Fire', 'Flying'],
 	};
 	static noGemMoves = [
 		'Fire Pledge',
@@ -2189,14 +2182,6 @@ class BattleTooltips {
 			itemName === 'Wise Glasses' && move.category === 'Special' ||
 			itemName === 'Punching Glove' && move.flags['punch']) {
 			value.itemModify(1.1);
-		}
-		
-		//Vaporemons
-		if (itemName === 'Baseball Bat' && move.flags['contact']) {
-			value.itemModify(1.25);
-		} 
-		if (moveType === 'Water' && itemName === 'Hero\'s Bubble' && speciesName === 'Palafin') {
-			value.itemModify(2);
 		}
 		
 		return value;

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1077,7 +1077,7 @@ class BattleTooltips {
 				stats.def = Math.floor(stats.def * 1.3);
 				stats.spd = Math.floor(stats.spd * 1.3);
 			} else if (speciesName === 'Kleavor') {
-				stats.atk = Math.floor(stats.atk * 1.5);
+				stats.atk *= 1.5;
 			}
 		}
 
@@ -1111,7 +1111,7 @@ class BattleTooltips {
 		}
 		if (ability === 'purepower' || ability === 'hugepower') {
 			stats.atk *= 2;
-		}
+		}	
 		if (ability === 'hustle' || (ability === 'gorillatactics' && !clientPokemon?.volatiles['dynamax'])) {
 			stats.atk = Math.floor(stats.atk * 1.5);
 		}
@@ -1173,12 +1173,12 @@ class BattleTooltips {
 			for (const statName of Dex.statNamesExceptHP) {
 				if (
 					clientPokemon.volatiles['protosynthesis' + statName] || clientPokemon.volatiles['quarkdrive' + statName] ||
-
+					
 					//Vaporemons
 					clientPokemon.volatiles['protomosis' + statName] || clientPokemon.volatiles['photondrive' + statName] ||
 					clientPokemon.volatiles['protocrysalis' + statName] || clientPokemon.volatiles['neurondrive' + statName] ||
-					clientPokemon.volatiles['protostasis' + statName] || clientPokemon.volatiles['runedrive' + statName] ||
-				) { {
+					clientPokemon.volatiles['protostasis' + statName] || clientPokemon.volatiles['runedrive' + statName]
+				) {
 					if (statName === 'spe') {
 						speedModifiers.push(1.5);
 					} else {
@@ -1928,6 +1928,7 @@ class BattleTooltips {
 						: undefined);
 			}
 			if (!value.value) return value;
+			
 			if (this.battle.weather === 'sandstorm') {
 				if (value.tryAbility("Sand Force")) value.weatherModify(1.3, "Sandstorm", "Sand Force");
 			}
@@ -2114,10 +2115,9 @@ class BattleTooltips {
 		if (this.battle.gen > 2 && serverPokemon.status === 'brn' && move.id !== 'facade' && move.category === 'Physical') {
 			if (!value.tryAbility("Guts")) value.modify(0.5, 'Burn');
 		}
-		//Vaporemons
-		/*if (this.battle.mod === 'gen9vaporemons' && serverPokemon.status === 'brn' && move.id !== 'lashout' && move.category === 'Physical') {
+		if (this.battle.mod === 'gen9vaporemons' && serverPokemon.status === 'brn' && move.id !== 'lashout' && move.category === 'Physical') {
 			if (!value.tryAbility("Guts")) value.modify(0.5, 'Burn');
-		}*/
+		}
 
 		if (
 			move.id === 'steelroller' &&
@@ -2168,7 +2168,6 @@ class BattleTooltips {
 		
 		//Vaporemons
 		'Charizard': ['Charizardite Shard X', 'Charizardite Shard Y'],
-		//'Revavroom': ['Segin Star Shard', 'Schedar Star Shard', 'Navi Star Shard', 'Ruchbah Star Shard', 'Caph Star Shard'],
 	};
 	static orbTypes: {[itemName: string]: TypeName[]} = {
 		'Soul Dew': ['Psychic', 'Dragon'],
@@ -2181,11 +2180,6 @@ class BattleTooltips {
 		'Vile Vial': ['Poison', 'Flying'],
 		
 		//Vaporemons
-		//'Segin Star Shard': ['Poison', 'Steel', 'Dark'],
-		//'Schedar Star Shard': ['Poison', 'Steel', 'Fire'],
-		//'Navi Star Shard': ['Poison', 'Steel'],
-		//'Ruchbah Star Shard': ['Poison', 'Steel', 'Fairy'],
-		//'Caph Star Shard': ['Poison', 'Steel', 'Fighting'],
 		'Charizardite Shard X': ['Fire', 'Dragon'],
 		'Charizardite Shard Y': ['Fire', 'Flying'],
 	};

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1222,7 +1222,11 @@ class BattleTooltips {
 			stats.spd = Math.floor(stats.spd * 1.5);
 		}
 		if (ability === 'grasspelt' && this.battle.hasPseudoWeather('Grassy Terrain')) {
-			stats.def = Math.floor(stats.def * 1.5);
+			if (this.battle.mod === 'gen9vaporemons') {
+				stats.def = Math.floor(stats.def * 1.3333);
+			} else {
+				stats.def = Math.floor(stats.def * 1.5);
+			}
 		}
 		if (this.battle.hasPseudoWeather('Electric Terrain')) {
 			if (ability === 'surgesurfer') {

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1177,8 +1177,8 @@ class BattleTooltips {
 					//Vaporemons
 					clientPokemon.volatiles['protomosis' + statName] || clientPokemon.volatiles['photondrive' + statName] ||
 					clientPokemon.volatiles['protocrysalis' + statName] || clientPokemon.volatiles['neurondrive' + statName] ||
-					clientPokemon.volatiles['protostasis' + statName] || clientPokemon.volatiles['runedrive' + statName]
-				) {
+					clientPokemon.volatiles['protostasis' + statName] || clientPokemon.volatiles['runedrive' + statName] ||
+				) { {
 					if (statName === 'spe') {
 						speedModifiers.push(1.5);
 					} else {
@@ -1931,7 +1931,7 @@ class BattleTooltips {
 			if (this.battle.weather === 'sandstorm') {
 				if (value.tryAbility("Sand Force")) value.weatherModify(1.3, "Sandstorm", "Sand Force");
 			}
-			/*if (move.category === 'Physical') {
+			if (move.category === 'Physical') {
 				value.abilityModify(1.5, "Blunt Force");
 			}
 			if (move.category === 'Special') {
@@ -1943,9 +1943,6 @@ class BattleTooltips {
 			if (move.id === 'naturalgift') {
 				value.abilityModify(2, "Harvest");
 			}
-			if (['muddywater', 'mudbomb', 'mudslap', 'mudshot'].includes(move.id)) {
-				value.abilityModify(2, "Mud Wash");
-			}*/
 		}
 		// Base power based on times hit
 		if (this.battle.mod !== 'gen9vaporemons' && move.id === 'ragefist') {
@@ -2118,9 +2115,9 @@ class BattleTooltips {
 			if (!value.tryAbility("Guts")) value.modify(0.5, 'Burn');
 		}
 		//Vaporemons
-		if (this.battle.mod === 'gen9vaporemons' && serverPokemon.status === 'brn' && move.id !== 'lashout' && move.category === 'Physical') {
+		/*if (this.battle.mod === 'gen9vaporemons' && serverPokemon.status === 'brn' && move.id !== 'lashout' && move.category === 'Physical') {
 			if (!value.tryAbility("Guts")) value.modify(0.5, 'Burn');
-		}
+		}*/
 
 		if (
 			move.id === 'steelroller' &&
@@ -2266,14 +2263,14 @@ class BattleTooltips {
 				itemName === 'Razor Fang' && move.flags['bite'] || 
 				itemName === 'Razor Claw' && move.flags['slicing'] || 
 				itemName === 'Quick Claw' && move.priority > 0.1) {
-				//itemName === 'Protective Pads' && (move.recoil || move.hasCrashDamage) || 
-				//itemName === 'Tie-Dye Band' && !this.pokemonHasType(pokemon, moveType)
 				value.itemModify(1.3);
 			} if (itemName === 'Baseball Bat' && move.flags['contact']) {
 				value.itemModify(1.25);
 			} if (moveType === 'Water' && itemName === 'Hero\'s Bubble' && speciesName === 'Palafin') {
 				value.itemModify(2);
-			}
+			} /*if (itemName === 'Binding Band' && target.volatiles['partiallytrapped']) {
+				value.itemModify(1.5);
+			}*/
 		}
 
 		return value;

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1938,11 +1938,14 @@ class BattleTooltips {
 			if (move.category === 'Special') {
 				value.abilityModify(1.3, "Sheer Heart");
 			}
-			if (move.id === 'naturalgift') {
+			/*if (move.id === 'naturalgift') {
 				value.abilityModify(2, "Ripen");
 			}
 			if (move.id === 'naturalgift') {
 				value.abilityModify(2, "Harvest");
+			}*/
+			if (['muddywater', 'mudbomb', 'mudslap', 'mudshot'].includes(move.id)) {
+				value.abilityModify(2, "Mud Wash");
 			}
 		}
 		// Base power based on times hit
@@ -2169,6 +2172,7 @@ class BattleTooltips {
 		
 		//Vaporemons
 		'Charizard': ['Charizardite Shard X', 'Charizardite Shard Y'],
+		'Revavroom': ['Segin Star Shard', 'Schedar Star Shard', 'Navi Star Shard', 'Ruchbah Star Shard', 'Caph Star Shard'],
 	};
 	static orbTypes: {[itemName: string]: TypeName[]} = {
 		'Soul Dew': ['Psychic', 'Dragon'],
@@ -2181,6 +2185,11 @@ class BattleTooltips {
 		'Vile Vial': ['Poison', 'Flying'],
 		
 		//Vaporemons
+		'Segin Star Shard': ['Poison', 'Steel', 'Dark'],
+		'Schedar Star Shard': ['Poison', 'Steel', 'Fire'],
+		'Navi Star Shard': ['Poison', 'Steel'],
+		'Ruchbah Star Shard': ['Poison', 'Steel', 'Fairy'],
+		'Caph Star Shard': ['Poison', 'Steel', 'Fighting'],
 		'Charizardite Shard X': ['Fire', 'Dragon'],
 		'Charizardite Shard Y': ['Fire', 'Flying'],
 	};
@@ -2257,11 +2266,15 @@ class BattleTooltips {
 				itemName === 'Punching Glove' && move.flags['punch'] || 
 				itemName === 'Razor Fang' && move.flags['bite'] || 
 				itemName === 'Razor Claw' && move.flags['slicing'] || 
-				itemName === 'Quick Claw' && move.priority > 0.1) {
+				itemName === 'Quick Claw' && move.priority > 0.1 || 
+				itemName === 'Protective Pads' && (move.recoil || move.hasCrashDamage) || 
+				itemName === 'Tie-Dye Band' && !this.pokemonHasType(pokemon, moveType)) {
 				value.itemModify(1.3);
+			} if (itemName === 'Tie-Dye Band' && this.pokemonHasType(pokemon, moveType)) {
+				value.itemModify(0.67);
 			} if (itemName === 'Baseball Bat' && move.flags['contact']) {
 				value.itemModify(1.25);
-			} if (moveType === 'Water' && itemName === 'Hero\'s Bubble' && speciesName === 'Palafin') {
+			} if (moveType === 'Water' && itemName === 'Hero\'s Bubble' && pokemon.getSpeciesForme() === 'Palafin-Zero'') {
 				value.itemModify(2);
 			} /*if (itemName === 'Binding Band' && target.volatiles['partiallytrapped']) {
 				value.itemModify(1.5);

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1070,13 +1070,13 @@ class BattleTooltips {
 			}
 		}
 		//Vaporemons
-		if (this.battle.mod === 'vaporemons' && item === 'mantisclaw') {
+		if (this.battle.mod === 'gen9vaporemons' && item === 'mantisclaw') {
 			if (speciesName === 'Scyther') {
 				speedModifiers.push(1.5);
 			} else if (speciesName === 'Scizor') {
 				stats.def = Math.floor(stats.def * 1.3);
 				stats.spd = Math.floor(stats.spd * 1.3);
-			} else if (speciesName === 'Scyther') {
+			} else if (speciesName === 'Kleavor') {
 				stats.atk *= 1.5;
 			}
 		}
@@ -1111,11 +1111,7 @@ class BattleTooltips {
 		}
 		if (ability === 'purepower' || ability === 'hugepower') {
 			stats.atk *= 2;
-		}
-		//Vaporemons
-		if (ability === 'sheerheart') {
-			stats.atk *= 1.3;
-		}		
+		}	
 		if (ability === 'hustle' || (ability === 'gorillatactics' && !clientPokemon?.volatiles['dynamax'])) {
 			stats.atk = Math.floor(stats.atk * 1.5);
 		}
@@ -1181,7 +1177,7 @@ class BattleTooltips {
 					//Vaporemons
 					clientPokemon.volatiles['protomosis' + statName] || clientPokemon.volatiles['photondrive' + statName] ||
 					clientPokemon.volatiles['protocrysalis' + statName] || clientPokemon.volatiles['neurondrive' + statName] ||
-					clientPokemon.volatiles['protostasis' + statName] || clientPokemon.volatiles['runedrive' + statName] ||
+					clientPokemon.volatiles['protostasis' + statName] || clientPokemon.volatiles['runedrive' + statName]
 				) {
 					if (statName === 'spe') {
 						speedModifiers.push(1.5);
@@ -1214,7 +1210,7 @@ class BattleTooltips {
 		}
 		if (ability === 'grasspelt' && this.battle.hasPseudoWeather('Grassy Terrain')) {
 			//Vaporemons
-			if (this.battle.mod === 'vaporemons') {
+			if (this.battle.mod === 'gen9vaporemons') {
 				stats.def = Math.floor(stats.def * 1.3333);
 			} else {
 				stats.def = Math.floor(stats.def * 1.5);
@@ -1256,7 +1252,7 @@ class BattleTooltips {
 			stats.spd = Math.floor(stats.spd * 1.5);
 		}
 		//Vaporemons
-		if (this.battle.mod === 'vaporemons') {
+		if (this.battle.mod === 'gen9vaporemons') {
 			if (item === 'mithrilarmor') {
 				stats.def = Math.floor(stats.def * 1.2);
 			} if (item === 'snowglobe' && this.pokemonHasType(pokemon, 'Ice')) {
@@ -1589,6 +1585,11 @@ class BattleTooltips {
 			const stats = this.calculateModifiedStats(pokemon, serverPokemon, true);
 			if (stats.atk > stats.spa) category = 'Physical';
 		}
+		//Vaporemons
+		if (this.battle.mod === 'gen9vaporemons' && move.id === 'terablast' && item.id === 'terashard') {
+			const stats = this.calculateModifiedStats(pokemon, serverPokemon, true);
+			if (stats.atk > stats.spa) category = 'Physical';
+		}
 		return [moveType, category];
 	}
 
@@ -1730,17 +1731,17 @@ class BattleTooltips {
 			value.set(100, 'Tera Stellar boost');
 		}
 		//Vaporemons
-		if (this.battle.mod === 'vaporemons' && ['terablast'].includes(move.id) && serverPokemon.item) {
+		if (this.battle.mod === 'gen9vaporemons' && ['terablast'].includes(move.id) && serverPokemon.item) {
 			let item = Dex.items.get(serverPokemon.item);
 			if (item.id === 'terashard') {
 				value.set(100, 'Tera Shard boost');
 			}
 		}
-		if (this.battle.mod === 'vaporemons' && move.id === 'lashout') {
+		if (this.battle.mod === 'gen9vaporemons' && move.id === 'lashout') {
 			if (!['', 'slp', 'frz'].includes(pokemon.status)) {
 				value.modify(2, 'Lash Out + status');
 			} for (const boost of Object.values(pokemon.boosts)) {
-				else if (boost < 0) {
+				if (boost < 0) {
 					value.modify(2, 'Lash Out + stats lowered');
 				}
 			}
@@ -1918,9 +1919,8 @@ class BattleTooltips {
 				value.setRange(isGKLK ? 20 : 40, 120);
 			}
 		}
-		// Base power based on times hit
 		//Vaporemons
-		if (this.battle.mod === 'vaporemons') {
+		if (this.battle.mod === 'gen9vaporemons') {
 			if (move.id === 'ragefist' || move.id === 'ragingfury') {
 				value.set(Math.min(200, 50 + 50 * pokemon.timesAttacked),
 					pokemon.timesAttacked > 0
@@ -1928,11 +1928,15 @@ class BattleTooltips {
 						: undefined);
 			}
 			if (!value.value) return value;
+			
 			if (this.battle.weather === 'sandstorm') {
 				if (value.tryAbility("Sand Force")) value.weatherModify(1.3, "Sandstorm", "Sand Force");
 			}
 			if (move.category === 'Physical') {
 				value.abilityModify(1.5, "Blunt Force");
+			}
+			if (move.category === 'Special') {
+				value.abilityModify(1.3, "Sheer Heart");
 			}
 			if (move.id === 'naturalgift') {
 				value.abilityModify(2, "Ripen");
@@ -1941,7 +1945,8 @@ class BattleTooltips {
 				value.abilityModify(2, "Harvest");
 			}
 		}
-		if (this.battle.mod !== 'vaporemons' && move.id === 'ragefist') {
+		// Base power based on times hit
+		if (this.battle.mod !== 'gen9vaporemons' && move.id === 'ragefist') {
 			value.set(Math.min(350, 50 + 50 * pokemon.timesAttacked),
 				pokemon.timesAttacked > 0
 					? `Hit ${pokemon.timesAttacked} time${pokemon.timesAttacked > 1 ? 's' : ''}`
@@ -1968,7 +1973,7 @@ class BattleTooltips {
 		if (['psn', 'tox'].includes(pokemon.status) && move.category === 'Physical') {
 			value.abilityModify(1.5, "Toxic Boost");
 		}
-		if (this.battle.mod !== 'vaporemons' && ['Rock', 'Ground', 'Steel'].includes(moveType) && this.battle.weather === 'sandstorm') {
+		if (this.battle.mod !== 'gen9vaporemons' && ['Rock', 'Ground', 'Steel'].includes(moveType) && this.battle.weather === 'sandstorm') {
 			if (value.tryAbility("Sand Force")) value.weatherModify(1.3, "Sandstorm", "Sand Force");
 		}
 		if (move.secondaries) {
@@ -2035,7 +2040,7 @@ class BattleTooltips {
 					value.modify(1.3, 'Power Spot');
 				} else if (allyAbility === 'Steely Spirit' && moveType === 'Steel') {
 					//Vaporemons
-					if (this.battle.mod !== 'vaporemons') {
+					if (this.battle.mod !== 'gen9vaporemons') {
 						value.modify(1.5, 'Steely Spirit');
 					} else {
 						value.modify(2, 'Steely Spirit');
@@ -2108,6 +2113,9 @@ class BattleTooltips {
 
 		// Burn isn't really a base power modifier, so it needs to be applied after the Tera BP floor
 		if (this.battle.gen > 2 && serverPokemon.status === 'brn' && move.id !== 'facade' && move.category === 'Physical') {
+			if (!value.tryAbility("Guts")) value.modify(0.5, 'Burn');
+		}
+		if (this.battle.mod === 'gen9vaporemons' && serverPokemon.status === 'brn' && move.id !== 'lashout' && move.category === 'Physical') {
 			if (!value.tryAbility("Guts")) value.modify(0.5, 'Burn');
 		}
 
@@ -2238,12 +2246,12 @@ class BattleTooltips {
 
 		if (itemName === 'Muscle Band' && move.category === 'Physical' ||
 			itemName === 'Wise Glasses' && move.category === 'Special' ||
-			itemName === 'Punching Glove' && move.flags['punch'] && this.battle.mod !== 'vaporemons') {
+			itemName === 'Punching Glove' && move.flags['punch'] && this.battle.mod !== 'gen9vaporemons') {
 			value.itemModify(1.1);
 		}
 		
 		//Vaporemons
-		if (this.battle.mod === 'vaporemons') {
+		if (this.battle.mod === 'gen9vaporemons') {
 			if (itemName === 'Big Root' && move.flags['heal'] || 
 				itemName === 'Punching Glove' && move.flags['punch'] || 
 				itemName === 'Razor Fang' && move.flags['bite'] || 

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1893,7 +1893,6 @@ class BattleTooltips {
 				value.setRange(isGKLK ? 20 : 40, 120);
 			}
 		}
-		
 		// Base power based on times hit
 		if (move.id === 'ragefist') {
 			value.set(Math.min(350, 50 + 50 * pokemon.timesAttacked),
@@ -2183,7 +2182,7 @@ class BattleTooltips {
 			itemName === 'Punching Glove' && move.flags['punch']) {
 			value.itemModify(1.1);
 		}
-		
+
 		return value;
 	}
 	getPokemonTypes(pokemon: Pokemon | ServerPokemon, preterastallized = false): ReadonlyArray<TypeName> {

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1070,7 +1070,7 @@ class BattleTooltips {
 			}
 		}
 		//Vaporemons
-		if (this.battle.mod === 'gen9vaporemons' && item === 'mantisclaw') {
+		if (item === 'mantisclaw') {
 			if (speciesName === 'Scyther') {
 				speedModifiers.push(1.5);
 			} else if (speciesName === 'Scizor') {
@@ -1171,7 +1171,14 @@ class BattleTooltips {
 				speedModifiers.push(2);
 			}
 			for (const statName of Dex.statNamesExceptHP) {
-				if (clientPokemon.volatiles['protosynthesis' + statName] || clientPokemon.volatiles['quarkdrive' + statName]) {
+				if (
+					clientPokemon.volatiles['protosynthesis' + statName] || clientPokemon.volatiles['quarkdrive' + statName] ||
+					
+					//Vaporemons
+					clientPokemon.volatiles['protomosis' + statName] || clientPokemon.volatiles['photondrive' + statName] ||
+					clientPokemon.volatiles['protocrysalis' + statName] || clientPokemon.volatiles['neurondrive' + statName] ||
+					clientPokemon.volatiles['protostasis' + statName] || clientPokemon.volatiles['runedrive' + statName]
+				) {
 					if (statName === 'spe') {
 						speedModifiers.push(1.5);
 					} else {
@@ -1180,6 +1187,26 @@ class BattleTooltips {
 				}
 			}
 		}
+		//Vaporemons
+		if (item === 'tuffytuff' && (this.battle.dex.species.get(serverPokemon.speciesForme).id === 'igglybuff' || 
+			this.battle.dex.species.get(serverPokemon.speciesForme).id === 'jigglypuff' || 
+			this.battle.dex.species.get(serverPokemon.speciesForme).id === 'wigglytuff')) {
+			stats.def = Math.floor(stats.def * 2);
+			stats.spd = Math.floor(stats.spd * 2);
+		}
+		if (item === 'mithrilarmor') {
+			stats.def = Math.floor(stats.def * 1.2);
+		} 
+		if (item === 'snowglobe' && this.pokemonHasType(pokemon, 'Ice')) {
+			stats.def = Math.floor(stats.def * 1.5);
+		} 
+		if (item === 'sandclock' && this.pokemonHasType(pokemon, 'Rock')) {
+			stats.spd = Math.floor(stats.spd * 1.5);
+		} 
+		if (item === 'desertrose' && species === 'Florges' && this.battle.weather === 'sandstorm') {
+			stats.spd = Math.floor(stats.spd * 1.5);
+		}
+		
 		if (ability === 'marvelscale' && pokemon.status) {
 			stats.def = Math.floor(stats.def * 1.5);
 		}
@@ -1866,6 +1893,14 @@ class BattleTooltips {
 				value.setRange(isGKLK ? 20 : 40, 120);
 			}
 		}
+		//Vaporemons
+		if (move.category === 'Physical') {
+			value.abilityModify(1.5, "Blunt Force");
+		}
+		if (move.category === 'Special') {
+			value.abilityModify(1.3, "Sheer Heart");
+		}
+		
 		// Base power based on times hit
 		if (move.id === 'ragefist') {
 			value.set(Math.min(350, 50 + 50 * pokemon.timesAttacked),
@@ -2078,6 +2113,9 @@ class BattleTooltips {
 		'Palkia': ['Lustrous Globe', 'Lustrous Orb'],
 		'Giratina': ['Griseous Core', 'Griseous Orb'],
 		'Venomicon': ['Vile Vial'],
+		
+		//Vaporemons
+		'Charizard': ['Charizardite Shard X', 'Charizardite Shard Y'],
 	};
 	static orbTypes: {[itemName: string]: TypeName[]} = {
 		'Soul Dew': ['Psychic', 'Dragon'],
@@ -2088,6 +2126,10 @@ class BattleTooltips {
 		'Griseous Core': ['Ghost', 'Dragon'],
 		'Griseous Orb': ['Ghost', 'Dragon'],
 		'Vile Vial': ['Poison', 'Flying'],
+		
+		//Vaporemons
+		'Charizardite Shard X': ['Fire', 'Dragon'],
+		'Charizardite Shard Y': ['Fire', 'Flying'],
 	};
 	static noGemMoves = [
 		'Fire Pledge',
@@ -2155,7 +2197,15 @@ class BattleTooltips {
 			itemName === 'Punching Glove' && move.flags['punch']) {
 			value.itemModify(1.1);
 		}
-
+		
+		//Vaporemons
+		if (itemName === 'Baseball Bat' && move.flags['contact']) {
+			value.itemModify(1.25);
+		} 
+		if (moveType === 'Water' && itemName === 'Hero\'s Bubble' && speciesName === 'Palafin') {
+			value.itemModify(2);
+		}
+		
 		return value;
 	}
 	getPokemonTypes(pokemon: Pokemon | ServerPokemon, preterastallized = false): ReadonlyArray<TypeName> {

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1111,7 +1111,7 @@ class BattleTooltips {
 		}
 		if (ability === 'purepower' || ability === 'hugepower') {
 			stats.atk *= 2;
-		}	
+		}
 		if (ability === 'hustle' || (ability === 'gorillatactics' && !clientPokemon?.volatiles['dynamax'])) {
 			stats.atk = Math.floor(stats.atk * 1.5);
 		}
@@ -1172,12 +1172,12 @@ class BattleTooltips {
 			}
 			for (const statName of Dex.statNamesExceptHP) {
 				if (
-					clientPokemon.volatiles['protosynthesis' + statName] || clientPokemon.volatiles['quarkdrive' + statName] ||
+					clientPokemon.volatiles['protosynthesis' + statName] || clientPokemon.volatiles['quarkdrive' + statName]
 					
 					//Vaporemons
-					clientPokemon.volatiles['protomosis' + statName] || clientPokemon.volatiles['photondrive' + statName] ||
-					clientPokemon.volatiles['protocrysalis' + statName] || clientPokemon.volatiles['neurondrive' + statName] ||
-					clientPokemon.volatiles['protostasis' + statName] || clientPokemon.volatiles['runedrive' + statName]
+					|| clientPokemon.volatiles['protomosis' + statName] || clientPokemon.volatiles['photondrive' + statName]
+					|| clientPokemon.volatiles['protocrysalis' + statName] || clientPokemon.volatiles['neurondrive' + statName]
+					|| clientPokemon.volatiles['protostasis' + statName] || clientPokemon.volatiles['runedrive' + statName]
 				) {
 					if (statName === 'spe') {
 						speedModifiers.push(1.5);
@@ -2115,6 +2115,7 @@ class BattleTooltips {
 		if (this.battle.gen > 2 && serverPokemon.status === 'brn' && move.id !== 'facade' && move.category === 'Physical') {
 			if (!value.tryAbility("Guts")) value.modify(0.5, 'Burn');
 		}
+		//Vaporemons
 		if (this.battle.mod === 'gen9vaporemons' && serverPokemon.status === 'brn' && move.id !== 'lashout' && move.category === 'Physical') {
 			if (!value.tryAbility("Guts")) value.modify(0.5, 'Burn');
 		}

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1172,12 +1172,12 @@ class BattleTooltips {
 			}
 			for (const statName of Dex.statNamesExceptHP) {
 				if (
-					clientPokemon.volatiles['protosynthesis' + statName] || clientPokemon.volatiles['quarkdrive' + statName]
+					clientPokemon.volatiles['protosynthesis' + statName] || clientPokemon.volatiles['quarkdrive' + statName] || 
 					
 					//Vaporemons
-					|| clientPokemon.volatiles['protomosis' + statName] || clientPokemon.volatiles['photondrive' + statName]
-					|| clientPokemon.volatiles['protocrysalis' + statName] || clientPokemon.volatiles['neurondrive' + statName]
-					|| clientPokemon.volatiles['protostasis' + statName] || clientPokemon.volatiles['runedrive' + statName]
+					clientPokemon.volatiles['protomosis' + statName] || clientPokemon.volatiles['photondrive' + statName] || 
+					clientPokemon.volatiles['protocrysalis' + statName] || clientPokemon.volatiles['neurondrive' + statName] || 
+					clientPokemon.volatiles['protostasis' + statName] || clientPokemon.volatiles['runedrive' + statName] 
 				) {
 					if (statName === 'spe') {
 						speedModifiers.push(1.5);
@@ -1932,21 +1932,21 @@ class BattleTooltips {
 			if (this.battle.weather === 'sandstorm') {
 				if (value.tryAbility("Sand Force")) value.weatherModify(1.3, "Sandstorm", "Sand Force");
 			}
-			if (move.category === 'Physical') {
+			/*if (move.category === 'Physical') {
 				value.abilityModify(1.5, "Blunt Force");
 			}
 			if (move.category === 'Special') {
 				value.abilityModify(1.3, "Sheer Heart");
 			}
-			/*if (move.id === 'naturalgift') {
+			if (move.id === 'naturalgift') {
 				value.abilityModify(2, "Ripen");
 			}
 			if (move.id === 'naturalgift') {
 				value.abilityModify(2, "Harvest");
-			}*/
+			}
 			if (['muddywater', 'mudbomb', 'mudslap', 'mudshot'].includes(move.id)) {
 				value.abilityModify(2, "Mud Wash");
-			}
+			}*/
 		}
 		// Base power based on times hit
 		if (this.battle.mod !== 'gen9vaporemons' && move.id === 'ragefist') {
@@ -2172,7 +2172,7 @@ class BattleTooltips {
 		
 		//Vaporemons
 		'Charizard': ['Charizardite Shard X', 'Charizardite Shard Y'],
-		'Revavroom': ['Segin Star Shard', 'Schedar Star Shard', 'Navi Star Shard', 'Ruchbah Star Shard', 'Caph Star Shard'],
+		//'Revavroom': ['Segin Star Shard', 'Schedar Star Shard', 'Navi Star Shard', 'Ruchbah Star Shard', 'Caph Star Shard'],
 	};
 	static orbTypes: {[itemName: string]: TypeName[]} = {
 		'Soul Dew': ['Psychic', 'Dragon'],
@@ -2185,11 +2185,11 @@ class BattleTooltips {
 		'Vile Vial': ['Poison', 'Flying'],
 		
 		//Vaporemons
-		'Segin Star Shard': ['Poison', 'Steel', 'Dark'],
-		'Schedar Star Shard': ['Poison', 'Steel', 'Fire'],
-		'Navi Star Shard': ['Poison', 'Steel'],
-		'Ruchbah Star Shard': ['Poison', 'Steel', 'Fairy'],
-		'Caph Star Shard': ['Poison', 'Steel', 'Fighting'],
+		//'Segin Star Shard': ['Poison', 'Steel', 'Dark'],
+		//'Schedar Star Shard': ['Poison', 'Steel', 'Fire'],
+		//'Navi Star Shard': ['Poison', 'Steel'],
+		//'Ruchbah Star Shard': ['Poison', 'Steel', 'Fairy'],
+		//'Caph Star Shard': ['Poison', 'Steel', 'Fighting'],
 		'Charizardite Shard X': ['Fire', 'Dragon'],
 		'Charizardite Shard Y': ['Fire', 'Flying'],
 	};
@@ -2262,19 +2262,21 @@ class BattleTooltips {
 		
 		//Vaporemons
 		if (this.battle.mod === 'gen9vaporemons') {
-			if (itemName === 'Big Root' && move.flags['heal'] || 
+			if (
+				itemName === 'Big Root' && move.flags['heal'] || 
 				itemName === 'Punching Glove' && move.flags['punch'] || 
 				itemName === 'Razor Fang' && move.flags['bite'] || 
 				itemName === 'Razor Claw' && move.flags['slicing'] || 
-				itemName === 'Quick Claw' && move.priority > 0.1 || 
-				itemName === 'Protective Pads' && (move.recoil || move.hasCrashDamage) || 
-				itemName === 'Tie-Dye Band' && !this.pokemonHasType(pokemon, moveType)) {
+				itemName === 'Quick Claw' && move.priority > 0.1 //|| 
+				//itemName === 'Protective Pads' && (move.recoil || move.hasCrashDamage) || 
+				//itemName === 'Tie-Dye Band' && !this.pokemonHasType(pokemon, moveType)
+			) {
 				value.itemModify(1.3);
-			} if (itemName === 'Tie-Dye Band' && this.pokemonHasType(pokemon, moveType)) {
-				value.itemModify(0.67);
+			//} if (itemName === 'Tie-Dye Band' && this.pokemonHasType(pokemon, moveType)) {
+			//	value.itemModify(0.67);
 			} if (itemName === 'Baseball Bat' && move.flags['contact']) {
 				value.itemModify(1.25);
-			} if (moveType === 'Water' && itemName === 'Hero\'s Bubble' && pokemon.getSpeciesForme() === 'Palafin-Zero'') {
+			} if (moveType === 'Water' && itemName === 'Hero\'s Bubble' && speciesName === 'Palafin'/*pokemon.getSpeciesForme() === 'Palafin'*/) {
 				value.itemModify(2);
 			} /*if (itemName === 'Binding Band' && target.volatiles['partiallytrapped']) {
 				value.itemModify(1.5);

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1077,7 +1077,7 @@ class BattleTooltips {
 				stats.def = Math.floor(stats.def * 1.3);
 				stats.spd = Math.floor(stats.spd * 1.3);
 			} else if (speciesName === 'Kleavor') {
-				stats.atk *= 1.5;
+				stats.atk = Math.floor(stats.atk * 1.5);
 			}
 		}
 
@@ -1111,7 +1111,7 @@ class BattleTooltips {
 		}
 		if (ability === 'purepower' || ability === 'hugepower') {
 			stats.atk *= 2;
-		}	
+		}
 		if (ability === 'hustle' || (ability === 'gorillatactics' && !clientPokemon?.volatiles['dynamax'])) {
 			stats.atk = Math.floor(stats.atk * 1.5);
 		}
@@ -1171,14 +1171,7 @@ class BattleTooltips {
 				speedModifiers.push(2);
 			}
 			for (const statName of Dex.statNamesExceptHP) {
-				if (
-					clientPokemon.volatiles['protosynthesis' + statName] || clientPokemon.volatiles['quarkdrive' + statName] ||
-					
-					//Vaporemons
-					clientPokemon.volatiles['protomosis' + statName] || clientPokemon.volatiles['photondrive' + statName] ||
-					clientPokemon.volatiles['protocrysalis' + statName] || clientPokemon.volatiles['neurondrive' + statName] ||
-					clientPokemon.volatiles['protostasis' + statName] || clientPokemon.volatiles['runedrive' + statName]
-				) {
+				if (clientPokemon.volatiles['protosynthesis' + statName] || clientPokemon.volatiles['quarkdrive' + statName]) {
 					if (statName === 'spe') {
 						speedModifiers.push(1.5);
 					} else {
@@ -1201,20 +1194,8 @@ class BattleTooltips {
 			stats.def = Math.floor(stats.def * 1.5);
 			stats.spd = Math.floor(stats.spd * 1.5);
 		}
-		//Vaporemons
-		if (item === 'tuffytuff' && (this.battle.dex.species.get(serverPokemon.speciesForme).id === 'igglybuff' || 
-			this.battle.dex.species.get(serverPokemon.speciesForme).id === 'jigglypuff' || 
-			this.battle.dex.species.get(serverPokemon.speciesForme).id === 'wigglytuff')) {
-			stats.def = Math.floor(stats.def * 2);
-			stats.spd = Math.floor(stats.spd * 2);
-		}
 		if (ability === 'grasspelt' && this.battle.hasPseudoWeather('Grassy Terrain')) {
-			//Vaporemons
-			if (this.battle.mod === 'gen9vaporemons') {
-				stats.def = Math.floor(stats.def * 1.3333);
-			} else {
-				stats.def = Math.floor(stats.def * 1.5);
-			}
+			stats.def = Math.floor(stats.def * 1.5);
 		}
 		if (this.battle.hasPseudoWeather('Electric Terrain')) {
 			if (ability === 'surgesurfer') {
@@ -1250,18 +1231,6 @@ class BattleTooltips {
 		}
 		if (item === 'assaultvest') {
 			stats.spd = Math.floor(stats.spd * 1.5);
-		}
-		//Vaporemons
-		if (this.battle.mod === 'gen9vaporemons') {
-			if (item === 'mithrilarmor') {
-				stats.def = Math.floor(stats.def * 1.2);
-			} if (item === 'snowglobe' && this.pokemonHasType(pokemon, 'Ice')) {
-				stats.def = Math.floor(stats.def * 1.5);
-			} if (item === 'sandclock' && this.pokemonHasType(pokemon, 'Rock')) {
-				stats.spd = Math.floor(stats.spd * 1.5);
-			} if (item === 'desertrose' && species === 'Florges' && this.battle.weather === 'sandstorm') {
-				stats.spd = Math.floor(stats.spd * 1.5);
-			}
 		}
 		if (item === 'deepseascale' && species === 'Clamperl') {
 			stats.spd *= 2;
@@ -1585,11 +1554,6 @@ class BattleTooltips {
 			const stats = this.calculateModifiedStats(pokemon, serverPokemon, true);
 			if (stats.atk > stats.spa) category = 'Physical';
 		}
-		//Vaporemons
-		if (this.battle.mod === 'gen9vaporemons' && move.id === 'terablast' && item.id === 'terashard') {
-			const stats = this.calculateModifiedStats(pokemon, serverPokemon, true);
-			if (stats.atk > stats.spa) category = 'Physical';
-		}
 		return [moveType, category];
 	}
 
@@ -1730,23 +1694,6 @@ class BattleTooltips {
 		if (['terablast'].includes(move.id) && pokemon.terastallized === 'Stellar') {
 			value.set(100, 'Tera Stellar boost');
 		}
-		//Vaporemons
-		if (this.battle.mod === 'gen9vaporemons' && ['terablast'].includes(move.id) && serverPokemon.item) {
-			let item = Dex.items.get(serverPokemon.item);
-			if (item.id === 'terashard') {
-				value.set(100, 'Tera Shard boost');
-			}
-		}
-		if (this.battle.mod === 'gen9vaporemons' && move.id === 'lashout') {
-			if (!['', 'slp', 'frz'].includes(pokemon.status)) {
-				value.modify(2, 'Lash Out + status');
-			} for (const boost of Object.values(pokemon.boosts)) {
-				if (boost < 0) {
-					value.modify(2, 'Lash Out + stats lowered');
-				}
-			}
-		}
-		
 		if (move.id === 'brine' && target && target.hp * 2 <= target.maxhp) {
 			value.modify(2, 'Brine + target below half HP');
 		}
@@ -1919,34 +1866,8 @@ class BattleTooltips {
 				value.setRange(isGKLK ? 20 : 40, 120);
 			}
 		}
-		//Vaporemons
-		if (this.battle.mod === 'gen9vaporemons') {
-			if (move.id === 'ragefist' || move.id === 'ragingfury') {
-				value.set(Math.min(200, 50 + 50 * pokemon.timesAttacked),
-					pokemon.timesAttacked > 0
-						? `Hit ${pokemon.timesAttacked} time${pokemon.timesAttacked > 1 ? 's' : ''}`
-						: undefined);
-			}
-			if (!value.value) return value;
-			
-			if (this.battle.weather === 'sandstorm') {
-				if (value.tryAbility("Sand Force")) value.weatherModify(1.3, "Sandstorm", "Sand Force");
-			}
-			if (move.category === 'Physical') {
-				value.abilityModify(1.5, "Blunt Force");
-			}
-			if (move.category === 'Special') {
-				value.abilityModify(1.3, "Sheer Heart");
-			}
-			if (move.id === 'naturalgift') {
-				value.abilityModify(2, "Ripen");
-			}
-			if (move.id === 'naturalgift') {
-				value.abilityModify(2, "Harvest");
-			}
-		}
 		// Base power based on times hit
-		if (this.battle.mod !== 'gen9vaporemons' && move.id === 'ragefist') {
+		if (move.id === 'ragefist') {
 			value.set(Math.min(350, 50 + 50 * pokemon.timesAttacked),
 				pokemon.timesAttacked > 0
 					? `Hit ${pokemon.timesAttacked} time${pokemon.timesAttacked > 1 ? 's' : ''}`
@@ -1973,7 +1894,7 @@ class BattleTooltips {
 		if (['psn', 'tox'].includes(pokemon.status) && move.category === 'Physical') {
 			value.abilityModify(1.5, "Toxic Boost");
 		}
-		if (this.battle.mod !== 'gen9vaporemons' && ['Rock', 'Ground', 'Steel'].includes(moveType) && this.battle.weather === 'sandstorm') {
+		if (['Rock', 'Ground', 'Steel'].includes(moveType) && this.battle.weather === 'sandstorm') {
 			if (value.tryAbility("Sand Force")) value.weatherModify(1.3, "Sandstorm", "Sand Force");
 		}
 		if (move.secondaries) {
@@ -2039,12 +1960,7 @@ class BattleTooltips {
 				} else if (allyAbility === 'Power Spot' && ally !== pokemon) {
 					value.modify(1.3, 'Power Spot');
 				} else if (allyAbility === 'Steely Spirit' && moveType === 'Steel') {
-					//Vaporemons
-					if (this.battle.mod !== 'gen9vaporemons') {
-						value.modify(1.5, 'Steely Spirit');
-					} else {
-						value.modify(2, 'Steely Spirit');
-					}
+					value.modify(1.5, 'Steely Spirit');
 				}
 			}
 			for (const foe of pokemon.side.foe.active) {
@@ -2115,9 +2031,6 @@ class BattleTooltips {
 		if (this.battle.gen > 2 && serverPokemon.status === 'brn' && move.id !== 'facade' && move.category === 'Physical') {
 			if (!value.tryAbility("Guts")) value.modify(0.5, 'Burn');
 		}
-		if (this.battle.mod === 'gen9vaporemons' && serverPokemon.status === 'brn' && move.id !== 'lashout' && move.category === 'Physical') {
-			if (!value.tryAbility("Guts")) value.modify(0.5, 'Burn');
-		}
 
 		if (
 			move.id === 'steelroller' &&
@@ -2165,9 +2078,6 @@ class BattleTooltips {
 		'Palkia': ['Lustrous Globe', 'Lustrous Orb'],
 		'Giratina': ['Griseous Core', 'Griseous Orb'],
 		'Venomicon': ['Vile Vial'],
-		
-		//Vaporemons
-		'Charizard': ['Charizardite Shard X', 'Charizardite Shard Y'],
 	};
 	static orbTypes: {[itemName: string]: TypeName[]} = {
 		'Soul Dew': ['Psychic', 'Dragon'],
@@ -2178,10 +2088,6 @@ class BattleTooltips {
 		'Griseous Core': ['Ghost', 'Dragon'],
 		'Griseous Orb': ['Ghost', 'Dragon'],
 		'Vile Vial': ['Poison', 'Flying'],
-		
-		//Vaporemons
-		'Charizardite Shard X': ['Fire', 'Dragon'],
-		'Charizardite Shard Y': ['Fire', 'Flying'],
 	};
 	static noGemMoves = [
 		'Fire Pledge',
@@ -2246,25 +2152,8 @@ class BattleTooltips {
 
 		if (itemName === 'Muscle Band' && move.category === 'Physical' ||
 			itemName === 'Wise Glasses' && move.category === 'Special' ||
-			itemName === 'Punching Glove' && move.flags['punch'] && this.battle.mod !== 'gen9vaporemons') {
+			itemName === 'Punching Glove' && move.flags['punch']) {
 			value.itemModify(1.1);
-		}
-		
-		//Vaporemons
-		if (this.battle.mod === 'gen9vaporemons') {
-			if (itemName === 'Big Root' && move.flags['heal'] || 
-				itemName === 'Punching Glove' && move.flags['punch'] || 
-				itemName === 'Razor Fang' && move.flags['bite'] || 
-				itemName === 'Razor Claw' && move.flags['slicing'] || 
-				itemName === 'Quick Claw' && move.priority > 0.1) {
-				value.itemModify(1.3);
-			} if (itemName === 'Baseball Bat' && move.flags['contact']) {
-				value.itemModify(1.25);
-			} if (moveType === 'Water' && itemName === 'Hero\'s Bubble' && speciesName === 'Palafin') {
-				value.itemModify(2);
-			} /*if (itemName === 'Binding Band' && target.volatiles['partiallytrapped']) {
-				value.itemModify(1.5);
-			}*/
 		}
 
 		return value;

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1893,13 +1893,6 @@ class BattleTooltips {
 				value.setRange(isGKLK ? 20 : 40, 120);
 			}
 		}
-		//Vaporemons
-		if (move.category === 'Physical') {
-			value.abilityModify(1.5, "Blunt Force");
-		}
-		if (move.category === 'Special') {
-			value.abilityModify(1.3, "Sheer Heart");
-		}
 		
 		// Base power based on times hit
 		if (move.id === 'ragefist') {

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1069,6 +1069,17 @@ class BattleTooltips {
 				stats.atk *= 2;
 			}
 		}
+		//Vaporemons
+		if (this.battle.mod === 'vaporemons' && item === 'mantisclaw') {
+			if (speciesName === 'Scyther') {
+				speedModifiers.push(1.5);
+			} else if (speciesName === 'Scizor') {
+				stats.def = Math.floor(stats.def * 1.3);
+				stats.spd = Math.floor(stats.spd * 1.3);
+			} else if (speciesName === 'Scyther') {
+				stats.atk *= 1.5;
+			}
+		}
 
 		if (speciesName === 'Ditto' && !(clientPokemon && 'transform' in clientPokemon.volatiles)) {
 			if (item === 'quickpowder') {
@@ -1101,6 +1112,10 @@ class BattleTooltips {
 		if (ability === 'purepower' || ability === 'hugepower') {
 			stats.atk *= 2;
 		}
+		//Vaporemons
+		if (ability === 'sheerheart') {
+			stats.atk *= 1.3;
+		}		
 		if (ability === 'hustle' || (ability === 'gorillatactics' && !clientPokemon?.volatiles['dynamax'])) {
 			stats.atk = Math.floor(stats.atk * 1.5);
 		}
@@ -1160,7 +1175,14 @@ class BattleTooltips {
 				speedModifiers.push(2);
 			}
 			for (const statName of Dex.statNamesExceptHP) {
-				if (clientPokemon.volatiles['protosynthesis' + statName] || clientPokemon.volatiles['quarkdrive' + statName]) {
+				if (
+					clientPokemon.volatiles['protosynthesis' + statName] || clientPokemon.volatiles['quarkdrive' + statName] ||
+					
+					//Vaporemons
+					clientPokemon.volatiles['protomosis' + statName] || clientPokemon.volatiles['photondrive' + statName] ||
+					clientPokemon.volatiles['protocrysalis' + statName] || clientPokemon.volatiles['neurondrive' + statName] ||
+					clientPokemon.volatiles['protostasis' + statName] || clientPokemon.volatiles['runedrive' + statName] ||
+				) {
 					if (statName === 'spe') {
 						speedModifiers.push(1.5);
 					} else {
@@ -1183,8 +1205,20 @@ class BattleTooltips {
 			stats.def = Math.floor(stats.def * 1.5);
 			stats.spd = Math.floor(stats.spd * 1.5);
 		}
+		//Vaporemons
+		if (item === 'tuffytuff' && (this.battle.dex.species.get(serverPokemon.speciesForme).id === 'igglybuff' || 
+			this.battle.dex.species.get(serverPokemon.speciesForme).id === 'jigglypuff' || 
+			this.battle.dex.species.get(serverPokemon.speciesForme).id === 'wigglytuff')) {
+			stats.def = Math.floor(stats.def * 2);
+			stats.spd = Math.floor(stats.spd * 2);
+		}
 		if (ability === 'grasspelt' && this.battle.hasPseudoWeather('Grassy Terrain')) {
-			stats.def = Math.floor(stats.def * 1.5);
+			//Vaporemons
+			if (this.battle.mod === 'vaporemons') {
+				stats.def = Math.floor(stats.def * 1.3333);
+			} else {
+				stats.def = Math.floor(stats.def * 1.5);
+			}
 		}
 		if (this.battle.hasPseudoWeather('Electric Terrain')) {
 			if (ability === 'surgesurfer') {
@@ -1220,6 +1254,18 @@ class BattleTooltips {
 		}
 		if (item === 'assaultvest') {
 			stats.spd = Math.floor(stats.spd * 1.5);
+		}
+		//Vaporemons
+		if (this.battle.mod === 'vaporemons') {
+			if (item === 'mithrilarmor') {
+				stats.def = Math.floor(stats.def * 1.2);
+			} if (item === 'snowglobe' && this.pokemonHasType(pokemon, 'Ice')) {
+				stats.def = Math.floor(stats.def * 1.5);
+			} if (item === 'sandclock' && this.pokemonHasType(pokemon, 'Rock')) {
+				stats.spd = Math.floor(stats.spd * 1.5);
+			} if (item === 'desertrose' && species === 'Florges' && this.battle.weather === 'sandstorm') {
+				stats.spd = Math.floor(stats.spd * 1.5);
+			}
 		}
 		if (item === 'deepseascale' && species === 'Clamperl') {
 			stats.spd *= 2;
@@ -1683,6 +1729,23 @@ class BattleTooltips {
 		if (['terablast'].includes(move.id) && pokemon.terastallized === 'Stellar') {
 			value.set(100, 'Tera Stellar boost');
 		}
+		//Vaporemons
+		if (this.battle.mod === 'vaporemons' && ['terablast'].includes(move.id) && serverPokemon.item) {
+			let item = Dex.items.get(serverPokemon.item);
+			if (item.id === 'terashard') {
+				value.set(100, 'Tera Shard boost');
+			}
+		}
+		if (this.battle.mod === 'vaporemons' && move.id === 'lashout') {
+			if (!['', 'slp', 'frz'].includes(pokemon.status)) {
+				value.modify(2, 'Lash Out + status');
+			} for (const boost of Object.values(pokemon.boosts)) {
+				else if (boost < 0) {
+					value.modify(2, 'Lash Out + stats lowered');
+				}
+			}
+		}
+		
 		if (move.id === 'brine' && target && target.hp * 2 <= target.maxhp) {
 			value.modify(2, 'Brine + target below half HP');
 		}
@@ -1856,7 +1919,29 @@ class BattleTooltips {
 			}
 		}
 		// Base power based on times hit
-		if (move.id === 'ragefist') {
+		//Vaporemons
+		if (this.battle.mod === 'vaporemons') {
+			if (move.id === 'ragefist' || move.id === 'ragingfury') {
+				value.set(Math.min(200, 50 + 50 * pokemon.timesAttacked),
+					pokemon.timesAttacked > 0
+						? `Hit ${pokemon.timesAttacked} time${pokemon.timesAttacked > 1 ? 's' : ''}`
+						: undefined);
+			}
+			if (!value.value) return value;
+			if (this.battle.weather === 'sandstorm') {
+				if (value.tryAbility("Sand Force")) value.weatherModify(1.3, "Sandstorm", "Sand Force");
+			}
+			if (move.category === 'Physical') {
+				value.abilityModify(1.5, "Blunt Force");
+			}
+			if (move.id === 'naturalgift') {
+				value.abilityModify(2, "Ripen");
+			}
+			if (move.id === 'naturalgift') {
+				value.abilityModify(2, "Harvest");
+			}
+		}
+		if (this.battle.mod !== 'vaporemons' && move.id === 'ragefist') {
 			value.set(Math.min(350, 50 + 50 * pokemon.timesAttacked),
 				pokemon.timesAttacked > 0
 					? `Hit ${pokemon.timesAttacked} time${pokemon.timesAttacked > 1 ? 's' : ''}`
@@ -1883,7 +1968,7 @@ class BattleTooltips {
 		if (['psn', 'tox'].includes(pokemon.status) && move.category === 'Physical') {
 			value.abilityModify(1.5, "Toxic Boost");
 		}
-		if (['Rock', 'Ground', 'Steel'].includes(moveType) && this.battle.weather === 'sandstorm') {
+		if (this.battle.mod !== 'vaporemons' && ['Rock', 'Ground', 'Steel'].includes(moveType) && this.battle.weather === 'sandstorm') {
 			if (value.tryAbility("Sand Force")) value.weatherModify(1.3, "Sandstorm", "Sand Force");
 		}
 		if (move.secondaries) {
@@ -1949,7 +2034,12 @@ class BattleTooltips {
 				} else if (allyAbility === 'Power Spot' && ally !== pokemon) {
 					value.modify(1.3, 'Power Spot');
 				} else if (allyAbility === 'Steely Spirit' && moveType === 'Steel') {
-					value.modify(1.5, 'Steely Spirit');
+					//Vaporemons
+					if (this.battle.mod !== 'vaporemons') {
+						value.modify(1.5, 'Steely Spirit');
+					} else {
+						value.modify(2, 'Steely Spirit');
+					}
 				}
 			}
 			for (const foe of pokemon.side.foe.active) {
@@ -2067,6 +2157,9 @@ class BattleTooltips {
 		'Palkia': ['Lustrous Globe', 'Lustrous Orb'],
 		'Giratina': ['Griseous Core', 'Griseous Orb'],
 		'Venomicon': ['Vile Vial'],
+		
+		//Vaporemons
+		'Charizard': ['Charizardite Shard X', 'Charizardite Shard Y'],
 	};
 	static orbTypes: {[itemName: string]: TypeName[]} = {
 		'Soul Dew': ['Psychic', 'Dragon'],
@@ -2077,6 +2170,10 @@ class BattleTooltips {
 		'Griseous Core': ['Ghost', 'Dragon'],
 		'Griseous Orb': ['Ghost', 'Dragon'],
 		'Vile Vial': ['Poison', 'Flying'],
+		
+		//Vaporemons
+		'Charizardite Shard X': ['Fire', 'Dragon'],
+		'Charizardite Shard Y': ['Fire', 'Flying'],
 	};
 	static noGemMoves = [
 		'Fire Pledge',
@@ -2141,8 +2238,25 @@ class BattleTooltips {
 
 		if (itemName === 'Muscle Band' && move.category === 'Physical' ||
 			itemName === 'Wise Glasses' && move.category === 'Special' ||
-			itemName === 'Punching Glove' && move.flags['punch']) {
+			itemName === 'Punching Glove' && move.flags['punch'] && this.battle.mod !== 'vaporemons') {
 			value.itemModify(1.1);
+		}
+		
+		//Vaporemons
+		if (this.battle.mod === 'vaporemons') {
+			if (itemName === 'Big Root' && move.flags['heal'] || 
+				itemName === 'Punching Glove' && move.flags['punch'] || 
+				itemName === 'Razor Fang' && move.flags['bite'] || 
+				itemName === 'Razor Claw' && move.flags['slicing'] || 
+				itemName === 'Quick Claw' && move.priority > 0.1) {
+				value.itemModify(1.3);
+			} if (itemName === 'Baseball Bat' && move.flags['contact']) {
+				value.itemModify(1.25);
+			} if (moveType === 'Water' && itemName === 'Hero\'s Bubble' && speciesName === 'Palafin') {
+				value.itemModify(2);
+			} /*if (itemName === 'Binding Band' && target.volatiles['partiallytrapped']) {
+				value.itemModify(1.5);
+			}*/
 		}
 
 		return value;

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1077,7 +1077,7 @@ class BattleTooltips {
 				stats.def = Math.floor(stats.def * 1.3);
 				stats.spd = Math.floor(stats.spd * 1.3);
 			} else if (speciesName === 'Kleavor') {
-				stats.atk *= 1.5;
+				stats.atk = Math.floor(stats.atk * 1.5);
 			}
 		}
 
@@ -1172,12 +1172,12 @@ class BattleTooltips {
 			}
 			for (const statName of Dex.statNamesExceptHP) {
 				if (
-					clientPokemon.volatiles['protosynthesis' + statName] || clientPokemon.volatiles['quarkdrive' + statName] || 
-					
+					clientPokemon.volatiles['protosynthesis' + statName] || clientPokemon.volatiles['quarkdrive' + statName] ||
+
 					//Vaporemons
-					clientPokemon.volatiles['protomosis' + statName] || clientPokemon.volatiles['photondrive' + statName] || 
-					clientPokemon.volatiles['protocrysalis' + statName] || clientPokemon.volatiles['neurondrive' + statName] || 
-					clientPokemon.volatiles['protostasis' + statName] || clientPokemon.volatiles['runedrive' + statName] 
+					clientPokemon.volatiles['protomosis' + statName] || clientPokemon.volatiles['photondrive' + statName] ||
+					clientPokemon.volatiles['protocrysalis' + statName] || clientPokemon.volatiles['neurondrive' + statName] ||
+					clientPokemon.volatiles['protostasis' + statName] || clientPokemon.volatiles['runedrive' + statName]
 				) {
 					if (statName === 'spe') {
 						speedModifiers.push(1.5);
@@ -1928,7 +1928,6 @@ class BattleTooltips {
 						: undefined);
 			}
 			if (!value.value) return value;
-			
 			if (this.battle.weather === 'sandstorm') {
 				if (value.tryAbility("Sand Force")) value.weatherModify(1.3, "Sandstorm", "Sand Force");
 			}
@@ -2262,25 +2261,19 @@ class BattleTooltips {
 		
 		//Vaporemons
 		if (this.battle.mod === 'gen9vaporemons') {
-			if (
-				itemName === 'Big Root' && move.flags['heal'] || 
+			if (itemName === 'Big Root' && move.flags['heal'] || 
 				itemName === 'Punching Glove' && move.flags['punch'] || 
 				itemName === 'Razor Fang' && move.flags['bite'] || 
 				itemName === 'Razor Claw' && move.flags['slicing'] || 
-				itemName === 'Quick Claw' && move.priority > 0.1 //|| 
+				itemName === 'Quick Claw' && move.priority > 0.1) {
 				//itemName === 'Protective Pads' && (move.recoil || move.hasCrashDamage) || 
 				//itemName === 'Tie-Dye Band' && !this.pokemonHasType(pokemon, moveType)
-			) {
 				value.itemModify(1.3);
-			//} if (itemName === 'Tie-Dye Band' && this.pokemonHasType(pokemon, moveType)) {
-			//	value.itemModify(0.67);
 			} if (itemName === 'Baseball Bat' && move.flags['contact']) {
 				value.itemModify(1.25);
-			} if (moveType === 'Water' && itemName === 'Hero\'s Bubble' && speciesName === 'Palafin'/*pokemon.getSpeciesForme() === 'Palafin'*/) {
+			} if (moveType === 'Water' && itemName === 'Hero\'s Bubble' && speciesName === 'Palafin') {
 				value.itemModify(2);
-			} /*if (itemName === 'Binding Band' && target.volatiles['partiallytrapped']) {
-				value.itemModify(1.5);
-			}*/
+			}
 		}
 
 		return value;


### PR DESCRIPTION
When I left, I forgot to share my progress on the whole tooltips thing. I experimented some with unfinished Solomods and Roovnen, but I feel confident that this may work. I will test things obviously. I just have this here to get feedback and keep y'all updated.

What currently works:
-
1. Paradox Abilities stat modifiers and proper volatile status
2. Healing Stones display (**_being shown as G-Max Steelspikes_**)
3. Tuffy-Tuff, Mantis Claw, Snow Globe, Sand Clock, Mithril Armor, Desert Rose

Does not work currently but will be looked at later:
-
1. Abilities: Sheer Heart, Blunt Force, Mud Wash, Grass Pelt, Sand Force, Steely Spirit
2. Items: Binding Band, Star Shards, Tie-Dye Band, Protective Pads, Baseball Bat, Punching Glove, Razor Fang, Razor Claw, Quick Claw, Hero's Bubble, Charizardite Shards, Tera Blast with Tera Shard, Big Root
3. Moves: Rage Fist, Raging Fury, Lash Out
