### PR TITLE
INHERITING SPRITES/CRIES IS BECOMING REAL

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -1760,15 +1760,55 @@ function buildModSprites() {
 		const subFolders = ['anifront', 'anifront-shiny','aniback','aniback-shiny','front', 'front-shiny', 'back', 'back-shiny', 'icons', 'types', 'items', 'cries'];
 		for (const j in subFolders) {
 			const subF = subFolders[j];
-			const spritePath = 'caches/DH2/data/mods/' + modName + (j === 'cries' ? '/audio/' : '/sprites/') + subF;
+			const spritePath = 'caches/DH2/data/mods/' + modName + (subF === 'cries' ? '/audio/cries' : ('/sprites/' + subF));
 			const spriteDir = fs.existsSync(spritePath) ? fs.readdirSync(spritePath) : '';
+			let inheritDataPresent = false;
 			for (const sprI in spriteDir) {
 				let id = spriteDir[sprI];
+				if (id === 'inherit') {
+					inheritDataPresent = true;
+					continue;
+				}
 				const ext = id.split(".")[1];
 				id = toID(id.slice(0, id.length - 4));
 				modSprites[id] ||= {};
 				modSprites[id][modName] ||= [];
-				modSprites[id][modName].push(subF);
+				modSprites[id][modName][subF] = null;
+			}
+			if (!inheritDataPresent) continue;
+			try {
+			//We're not outright making "inherit" a JSON because the other files would attempt to copypaste it and it would cause problems
+				const mappings = JSON.parse(fs.readFileSync(spritePath + "/inherit"));
+				for (const mon in mappings) {
+					//null is our indicator for the presence of a custom sprite already being uploaded
+					//Also you can't inherit from yourself
+					if (mappings[mon] === null || mappings[mon] === mon) continue;
+					modSprites[mon] ||= {};
+					modSprites[mon][modName] ||= {};
+					//Skip if we already have custom data on this mon
+					if (modSprites[mon][modName].hasOwnProperty(subF)) continue;
+					let inherited = mappings[mon];
+					if (modSprites[inherited] && modSprites[inherited][modName] && modSprites[inherited][modName].hasOwnProperty(subF)) {
+						//If we already decided that the inheritor inherits in of itself we inherit from that
+						//(cycles result in neither inheriting)
+						modSprites[mon][modName][subF] = modSprites[inherited][modName][subF]; 
+					} else {
+						//We don't have inherit data for this mapping, so let us inherit
+						while (mappings.hasOwnProperty(inherited) && inherited !== mon) {
+							//If there is a chain of inheritance track it to the source
+							inherited = mappings[inherited];
+						}
+						if (inherited === mon) {
+							//CYCLE SPOTTED, DO NOT INHERIT
+							modSprites[mon][modName][subF] = null;
+						} else {
+							//Now we inherit
+							modSprites[mon][modName][subF] = inherited;
+						}
+					}
+				}
+			} catch (e) {
+				console.log("WARNING: Failed to read inherit file under " + spritePath + " (it's meant to be formatted like a JSON)");
 			}
 		}
 	}

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -3584,8 +3584,8 @@
 			var baseid = toID(species.baseSpecies);
 			var forms = [baseid].concat(species.cosmeticFormes.map(toID));
 
-			let modSprite = Dex.getSpriteMod(mod, baseid, 'front', species.exists !== false)
-				|| Dex.getSpriteMod(mod, species.id, 'front', species.exists !== false);
+			let modSprite = Dex.getSpriteMod(mod, baseid, 'front', species.exists !== false).mod
+				|| Dex.getSpriteMod(mod, species.id, 'front', species.exists !== false).mod;
 			let resourcePrefix;
 			let d;
 			if (modSprite) {

--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -822,10 +822,14 @@ const Dex = new class implements ModdedDex {
 		Dex.species.get(id);
 		let species = window.BattlePokedexAltForms && window.BattlePokedexAltForms[id] ? window.BattlePokedexAltForms[id] : Dex.species.get(id);
 		const moddata = this.getSpriteMod(mod, id, 'icons', species.exists !== false);
-			//TODO: Have an inherited icon reflect fainting (That it doesn't is why this next line is commented out in the first place)
-		//if (moddata.inherit) return this.getPokemonIcon(moddata.inherit, facingLeft || false, mod);
-		mod = moddata.mod;
-		if (mod) return `background:transparent url(${this.modResourcePrefix}${mod}/sprites/icons/${id}.png) no-repeat scroll -0px -0px${fainted}`;
+		//TODO: Figure out a way for inherited sprites to show up as fainted
+		//("?" icons will be used as placeholders for fainted inherited sprites for the time being)
+		if (!moddata.inherit) {
+			mod = moddata.mod;
+			if (mod) return `background:transparent url(${this.modResourcePrefix}${mod}/sprites/icons/${id}.png) no-repeat scroll -0px -0px${fainted}`;
+		} else if (!fainted) {
+			return this.getPokemonIcon(moddata.inherit, facingLeft || false, mod);
+		}
 		return `background:transparent url(${Dex.resourcePrefix}sprites/pokemonicons-sheet.png?v16) no-repeat scroll -${left}px -${top}px${fainted}`;
 
 	}

--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -482,7 +482,7 @@ const Dex = new class implements ModdedDex {
 		if (optionsMod && window.ModSprites[spriteId][optionsMod]) {
 			for (const prefix of ['ani', '']) {
 				if (window.ModSprites[spriteId][optionsMod].hasOwnProperty(prefix + filepath))
-					//It won't matter if 
+					//It won't matter if it inherits in another mod or not, point is it has data in this mod
 					return {mod: optionsMod, inherit: window.ModSprites[spriteId][optionsMod][prefix + filepath]};
 			}
 		}
@@ -941,7 +941,7 @@ const Dex = new class implements ModdedDex {
 		}
 	}
 
-	//TODO: Support modded ones maybe?
+	//TODO: Support replaced sprites from mods maybe?
 	getCategoryIcon(category: string | null) {
 		const categoryID = toID(category);
 		let sanitizedCategory = '';

--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -826,7 +826,10 @@ const Dex = new class implements ModdedDex {
 		//("?" icons will be used as placeholders for fainted inherited sprites for the time being)
 		if (!moddata.inherit) {
 			mod = moddata.mod;
-			if (mod) return `background:transparent url(${this.modResourcePrefix}${mod}/sprites/icons/${id}.png) no-repeat scroll -0px -0px${fainted}`;
+			if (mod) {
+				//TODO: If female try and check if "../icons/${id}f" is available, fall back on the default if no such file is found (which is to say there are no gender differences in the icon)
+				return `background:transparent url(${this.modResourcePrefix}${mod}/sprites/icons/${id}.png) no-repeat scroll -0px -0px${fainted}`;
+			}
 		} else if (!fainted) {
 			return this.getPokemonIcon(moddata.inherit, facingLeft || false, mod);
 		}


### PR DESCRIPTION
You just plop an "inherit" file with JSON formatting in a specified cries/sprites folder and if a mon has an entry in that file but _does not_ have a sprite or cry in the same directory then it will look at whatever is listed for its entry and copy that thing's sprite or cry. (basically the other files in that directory override inherit file entries)

Also "substitute" mons with cry data actually play that cry data so the dependencies between cries and actual sprite data are now completely severed and retrieval of cry data has been moved into its own function, if custom cries aren't showing up chances are there was incorrect indexing and that should be fixed