### PR TITLE
Mons in a mod can share cries and/or sprites

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -1760,15 +1760,55 @@ function buildModSprites() {
 		const subFolders = ['anifront', 'anifront-shiny','aniback','aniback-shiny','front', 'front-shiny', 'back', 'back-shiny', 'icons', 'types', 'items', 'cries'];
 		for (const j in subFolders) {
 			const subF = subFolders[j];
-			const spritePath = 'caches/DH2/data/mods/' + modName + (j === 'cries' ? '/audio/' : '/sprites/') + subF;
+			const spritePath = 'caches/DH2/data/mods/' + modName + (subF === 'cries' ? '/audio/cries' : ('/sprites/' + subF));
 			const spriteDir = fs.existsSync(spritePath) ? fs.readdirSync(spritePath) : '';
+			let inheritDataPresent = false;
 			for (const sprI in spriteDir) {
 				let id = spriteDir[sprI];
+				if (id === 'inherit') {
+					inheritDataPresent = true;
+					continue;
+				}
 				const ext = id.split(".")[1];
 				id = toID(id.slice(0, id.length - 4));
 				modSprites[id] ||= {};
 				modSprites[id][modName] ||= [];
-				modSprites[id][modName].push(subF);
+				modSprites[id][modName][subF] = null;
+			}
+			if (!inheritDataPresent) continue;
+			try {
+			//We're not outright making "inherit" a JSON because the other files would attempt to copypaste it and it would cause problems
+				const mappings = JSON.parse(fs.readFileSync(spritePath + "/inherit"));
+				for (const mon in mappings) {
+					//null is our indicator for the presence of a custom sprite already being uploaded
+					//Also you can't inherit from yourself
+					if (mappings[mon] === null || mappings[mon] === mon) continue;
+					modSprites[mon] ||= {};
+					modSprites[mon][modName] ||= {};
+					//Skip if we already have custom data on this mon
+					if (modSprites[mon][modName].hasOwnProperty(subF)) continue;
+					let inherited = mappings[mon];
+					if (modSprites[inherited] && modSprites[inherited][modName] && modSprites[inherited][modName].hasOwnProperty(subF)) {
+						//If we already decided that the inheritor inherits in of itself we inherit from that
+						//(cycles result in neither inheriting)
+						modSprites[mon][modName][subF] = modSprites[inherited][modName][subF]; 
+					} else {
+						//We don't have inherit data for this mapping, so let us inherit
+						while (mappings.hasOwnProperty(inherited) && inherited !== mon) {
+							//If there is a chain of inheritance track it to the source
+							inherited = mappings[inherited];
+						}
+						if (inherited === mon) {
+							//CYCLE SPOTTED, DO NOT INHERIT
+							modSprites[mon][modName][subF] = null;
+						} else {
+							//Now we inherit
+							modSprites[mon][modName][subF] = inherited;
+						}
+					}
+				}
+			} catch (e) {
+				console.log("WARNING: Failed to read inherit file under " + spritePath + " (it's meant to be formatted like a JSON)");
 			}
 		}
 	}

--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -1765,7 +1765,7 @@ function buildModSprites() {
 			let inheritDataPresent = false;
 			for (const sprI in spriteDir) {
 				let id = spriteDir[sprI];
-				if (id === 'inherit') {
+				if (id === 'reused') {
 					inheritDataPresent = true;
 					continue;
 				}
@@ -1773,12 +1773,13 @@ function buildModSprites() {
 				id = toID(id.slice(0, id.length - 4));
 				modSprites[id] ||= {};
 				modSprites[id][modName] ||= [];
+				//TODO: Find a more space-efficient means of indicating which mons share certain resources in a given mod
 				modSprites[id][modName][subF] = null;
 			}
 			if (!inheritDataPresent) continue;
 			try {
 			//We're not outright making "inherit" a JSON because the other files would attempt to copypaste it and it would cause problems
-				const mappings = JSON.parse(fs.readFileSync(spritePath + "/inherit"));
+				const mappings = JSON.parse(fs.readFileSync(spritePath + "/reused"));
 				for (const mon in mappings) {
 					//null is our indicator for the presence of a custom sprite already being uploaded
 					//Also you can't inherit from yourself
@@ -1808,7 +1809,7 @@ function buildModSprites() {
 					}
 				}
 			} catch (e) {
-				console.log("WARNING: Failed to read inherit file under " + spritePath + " (it's meant to be formatted like a JSON)");
+				console.log("WARNING: Failed to read \"reused\" file under " + spritePath + " (it's meant to be formatted like a JSON)");
 			}
 		}
 	}

--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -1770,41 +1770,61 @@ function buildModSprites() {
 					continue;
 				}
 				const ext = id.split(".")[1];
+				//These are our supported file extensions, if missing we skip
+				if (!["png","gif","mp3"].includes(ext)) continue;
 				id = toID(id.slice(0, id.length - 4));
-				modSprites[id] ||= {};
-				modSprites[id][modName] ||= [];
-				//TODO: Find a more space-efficient means of indicating which mons share certain resources in a given mod
-				modSprites[id][modName][subF] = null;
+				if (!modSprites[id]) modSprites[id] = {[modName]: [subF]};
+				else if (!modSprites[id][modName]) modSprites[id][modName] = [subF];
+				else modSprites[id][modName].push(subF);
 			}
+			//We're not adding the .JSON extension outright because the other files would attempt to copypaste it and it would cause problems
 			if (!inheritDataPresent) continue;
 			try {
-			//We're not outright giving this file the .json suffix because the other files would attempt to copypaste it and it would cause problems
 				const mappings = JSON.parse(fs.readFileSync(spritePath + "/reused"));
 				for (const mon in mappings) {
-					//null is our indicator for the presence of a custom sprite already being uploaded
-					//Also you can't inherit from yourself
-					if (mappings[mon] === null || mappings[mon] === mon) continue;
-					modSprites[mon] ||= {};
-					modSprites[mon][modName] ||= {};
-					//Skip if we already have custom data on this mon
-					if (modSprites[mon][modName].hasOwnProperty(subF)) continue;
 					let inherited = mappings[mon];
-					if (modSprites[inherited] && modSprites[inherited][modName] && modSprites[inherited][modName].hasOwnProperty(subF)) {
-						//If we already decided that the inheritor inherits in of itself we inherit from that
-						//(cycles result in neither inheriting)
-						modSprites[mon][modName][subF] = modSprites[inherited][modName][subF]; 
+					//null is not valid to inherit from
+					//Also you can't inherit from yourself
+					if (inherited === null || inherited === mon) continue;
+					//Skip if we already have custom data on this mon
+					if (modSprites[mon] && modSprites[mon][modName] && modSprites[mon][modName].includes(subF)) continue;
+					if (!modSprites.ReusedResources[mon]) {
+						modSprites.ReusedResources[mon] = {[modName]: {}};
+					} else if (!modSprites.ReusedResources[mon][modName]) {
+						modSprites.ReusedResources[mon][modName] = {};
+					} else if (modSprites.ReusedResources[mon][modName].hasOwnProperty(subF)){
+						//We already handled this, it was presumably caught in an inherit chain
+						continue;
+					}
+					//If we already decided that the inheritor inherits in of itself we inherit from that
+					//(cycles result in neither inheriting)
+					if (modSprites.ReusedResources[inherited] && modSprites.ReusedResources[inherited][modName]
+						&& modSprites.ReusedResources[inherited][modName].hasOwnProperty(subF)) {
+						modSprites.ReusedResources[mon][modName][subF] = modSprites.ReusedResources[inherited][modName][subF]; 
 					} else {
 						//We don't have inherit data for this mapping, so let us inherit
-						while (mappings.hasOwnProperty(inherited) && inherited !== mon) {
-							//If there is a chain of inheritance track it to the source
+						const inheritChain = [mon];
+						//If there is a chain of inheritance track it to the source
+						//"inherited !== mon" breaks the loop if the inheritance is cyclic
+						while (mappings.hasOwnProperty(inherited) && inherited !== mon
+							//We're cutting off the inherit chain if we come across a preexisting element.
+							&& !(modSprites.hasOwnProperty(inherited) && modSprites[inherited].hasOwnProperty(modName)
+								&& modSprites[inherited][modName].contains(subF))) {
+							inheritChain.push(inherited);
 							inherited = mappings[inherited];
 						}
+						//If there's a cycle none of these guys are inheriting
 						if (inherited === mon) {
-							//CYCLE SPOTTED, DO NOT INHERIT
-							modSprites[mon][modName][subF] = null;
+							for (const chainInherit of inheritChain) {
+								modSprites[chainInherit] ||= {};
+								if (!modSprites[chainInherit].hasOwnProperty(modName)) modSprites[chainInherit][modName] = [subF];
+								else modSprites[chainInherit][modName].push(subF);
+							}
 						} else {
-							//Now we inherit
-							modSprites[mon][modName][subF] = inherited;
+							//We're inheriting here
+							for (const chainInherit of inheritChain) {
+								modSprites.ReusedResources[chainInherit][modName][subF] = inherited;
+							}
 						}
 					}
 				}

--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -1778,7 +1778,7 @@ function buildModSprites() {
 			}
 			if (!inheritDataPresent) continue;
 			try {
-			//We're not outright making "inherit" a JSON because the other files would attempt to copypaste it and it would cause problems
+			//We're not outright giving this file the .json suffix because the other files would attempt to copypaste it and it would cause problems
 				const mappings = JSON.parse(fs.readFileSync(spritePath + "/reused"));
 				for (const mon in mappings) {
 					//null is our indicator for the presence of a custom sprite already being uploaded

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -3584,8 +3584,8 @@
 			var baseid = toID(species.baseSpecies);
 			var forms = [baseid].concat(species.cosmeticFormes.map(toID));
 
-			let modSprite = Dex.getSpriteMod(mod, baseid, 'front', species.exists !== false)
-				|| Dex.getSpriteMod(mod, species.id, 'front', species.exists !== false);
+			let modSprite = Dex.getSpriteMod(mod, baseid, 'front', species.exists !== false).mod
+				|| Dex.getSpriteMod(mod, species.id, 'front', species.exists !== false).mod;
 			let resourcePrefix;
 			let d;
 			if (modSprite) {

--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -822,10 +822,14 @@ const Dex = new class implements ModdedDex {
 		Dex.species.get(id);
 		let species = window.BattlePokedexAltForms && window.BattlePokedexAltForms[id] ? window.BattlePokedexAltForms[id] : Dex.species.get(id);
 		const moddata = this.getSpriteMod(mod, id, 'icons', species.exists !== false);
-			//TODO: Have an inherited icon reflect fainting (That it doesn't is why this next line is commented out in the first place)
-		//if (moddata.inherit) return this.getPokemonIcon(moddata.inherit, facingLeft || false, mod);
-		mod = moddata.mod;
-		if (mod) return `background:transparent url(${this.modResourcePrefix}${mod}/sprites/icons/${id}.png) no-repeat scroll -0px -0px${fainted}`;
+		//TODO: Figure out a way for inherited sprites to show up as fainted
+		//("?" icons will be used as placeholders for fainted inherited sprites for the time being)
+		if (!moddata.inherit) {
+			mod = moddata.mod;
+			if (mod) return `background:transparent url(${this.modResourcePrefix}${mod}/sprites/icons/${id}.png) no-repeat scroll -0px -0px${fainted}`;
+		} else if (!fainted) {
+			return this.getPokemonIcon(moddata.inherit, facingLeft || false, mod);
+		}
 		return `background:transparent url(${Dex.resourcePrefix}sprites/pokemonicons-sheet.png?v16) no-repeat scroll -${left}px -${top}px${fainted}`;
 
 	}

--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -482,7 +482,7 @@ const Dex = new class implements ModdedDex {
 		if (optionsMod && window.ModSprites[spriteId][optionsMod]) {
 			for (const prefix of ['ani', '']) {
 				if (window.ModSprites[spriteId][optionsMod].hasOwnProperty(prefix + filepath))
-					//It won't matter if 
+					//It won't matter if it inherits in another mod or not, point is it has data in this mod
 					return {mod: optionsMod, inherit: window.ModSprites[spriteId][optionsMod][prefix + filepath]};
 			}
 		}
@@ -941,7 +941,7 @@ const Dex = new class implements ModdedDex {
 		}
 	}
 
-	//TODO: Support modded ones maybe?
+	//TODO: Support replaced sprites from mods maybe?
 	getCategoryIcon(category: string | null) {
 		const categoryID = toID(category);
 		let sanitizedCategory = '';

--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -965,7 +965,7 @@ const Dex = new class implements ModdedDex {
 		}
 	}
 
-	//TODO: Support replaced sprites from mods maybe?
+	//TODO: Support replaced category icons from mods maybe?
 	getCategoryIcon(category: string | null) {
 		const categoryID = toID(category);
 		let sanitizedCategory = '';

--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -826,7 +826,10 @@ const Dex = new class implements ModdedDex {
 		//("?" icons will be used as placeholders for fainted inherited sprites for the time being)
 		if (!moddata.inherit) {
 			mod = moddata.mod;
-			if (mod) return `background:transparent url(${this.modResourcePrefix}${mod}/sprites/icons/${id}.png) no-repeat scroll -0px -0px${fainted}`;
+			if (mod) {
+				//TODO: If female try and check if "../icons/${id}f" is available, fall back on the default if no such file is found (which is to say there are no gender differences in the icon)
+				return `background:transparent url(${this.modResourcePrefix}${mod}/sprites/icons/${id}.png) no-repeat scroll -0px -0px${fainted}`;
+			}
 		} else if (!fainted) {
 			return this.getPokemonIcon(moddata.inherit, facingLeft || false, mod);
 		}


### PR DESCRIPTION
Yes, even realmons can lend their cries to other mons; This should help if a bunch of mons have the same cry or share sprites (That Alternatium and its EX counterpart do this is the big thing that inspired me in the first place); NOTE THE TODOS THOUGH since I'm highly aware there could be better ways to implement this feature

Also this update lets mons have cries without the need for actual sprites so they might as well be decoupled