### PR TITLE
excludeStandardItems

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -1385,6 +1385,9 @@ function buildTeambuilderTables() {
 			for (const id in modData.Items) {
 				const modEntry = modData.Items[id];
 				const baseEntry = Dex.data.Items[id];
+				if(ModConfig[modConfigId].excludeStandardItems) {
+					if(ModConfig[modConfigId].customItems.indexOf(modEntry.name) == -1) continue;
+				}
 				if (typeof baseEntry === 'undefined') {
 					overrideItemInfo[id] = {};
 					overrideItemInfo[id] = modEntry;

--- a/play.pokemonshowdown.com/src/battle-animations.ts
+++ b/play.pokemonshowdown.com/src/battle-animations.ts
@@ -559,6 +559,11 @@ export class BattleScene implements BattleSceneStub {
 
 	updateGen() {
 		let gen = this.battle.gen;
+		// Mod Graphics override
+		const modid = this.battle.dex.modid;
+		const customGraphics = window.ModConfig[modid].graphicsGen;
+		if (customGraphics) gen = customGraphics;
+		// Respect prefs
 		if (Dex.prefs('nopastgens')) gen = 6;
 		if (Dex.prefs('bwgfx') && gen > 5) gen = 5;
 		this.gen = gen;

--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -1685,6 +1685,7 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 
 		const move = dex.moves.get(id);
 		if (!move.exists) return true;
+		if (BattleMovedex[id] === undefined) return false; // Fix for undefined moves
 		if (!BattleMovedex[id].exists) return true; //Flag custom moves as viable by default
 		if ((move.status === 'slp' || id === 'yawn') && dex.gen === 9 && !this.formatType) {
 			return false;

--- a/play.pokemonshowdown.com/src/battle-dex.ts
+++ b/play.pokemonshowdown.com/src/battle-dex.ts
@@ -583,6 +583,10 @@ const Dex = new class implements ModdedDex {
 		//     (eg. Darmanitan in graphicsGen 2) then we go up gens until it exists.
 		//
 		let graphicsGen = mechanicsGen;
+		// Mod Graphics override
+		const customGraphics = window.ModConfig[options.mod].graphicsGen;
+		if (customGraphics) graphicsGen = customGraphics;
+		// Respect prefs
 		if (Dex.prefs('nopastgens')) graphicsGen = 6;
 		if (Dex.prefs('bwgfx') && graphicsGen >= 6) graphicsGen = 5;
 		spriteData.gen = Math.max(graphicsGen, Math.min(species.gen, 5));


### PR DESCRIPTION
### What this does
Adds two new paramaters for custom mods to take advantage of: _excludeStandardItems_ and _customItems_

### How it works
This is modeled directly after _excludeStandardTiers_. If a mod has this paramater set to _true_, it will remove all items from the teambuilder list except those listed in a _customItems_ array. This would be great for metas with a reduced item list, so they actually disappear from the teambuilder instead of only being blocked during verification.

### Example
~~~ts
excludeStandardItems: true,
customItems: ["Leftovers", "Choice Band"],
~~~