### PR TITLE
Enable opting out of form-change animation (is this okay?)

### DIFF
--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -2534,7 +2534,8 @@ export class Battle {
 				this.activateAbility(poke, fromeffect);
 			}
 			poke.addVolatile('formechange' as ID, species.name); // the formechange volatile reminds us to revert the sprite change on switch-out
-			this.scene.animTransform(poke, true);
+			if (kwArgs.hideanim) this.scene.animTransform(poke);
+			else this.scene.animTransform(poke, true);
 			this.log(args, kwArgs);
 			break;
 		}


### PR DESCRIPTION
Right now, the form change animation is based on a hard-coded list of species in the client, and everything not on that list uses the flashy Mega Evolution animation.

This change should make it so people can add the argument '[hideanim]' to any form change line (server-side), like this:
> this.add('-formechange', pokemon, pokemon.species.name, '[hideanim]');

Adding that argument just tells the client that you want to use the shorter, more minimalist animation like Mimikyu and Aegislash.
This update changes nothing unless you specifically add '[hideanim]' to that line, so it won't affect anyone's existing code! but it's easy for anyone to use if they want it.
(I'm not sure if making this kind of change to the client is allowed, so feel free to just close this if not!)